### PR TITLE
Create high-memory node groups

### DIFF
--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -6,16 +6,28 @@ config:
   data-engineering-airflow:eks:
     cluster:
       kubernetes_version: "1.21"
-      node_group:
-        ami_release_version: 1.21.4-20211013
-        instance_types:
-          - t3a.small
-          - t3.small
-          - t2.small
-        scaling_config:
-          desired_size: 1
-          max_size: 2
-          min_size: 1
+      node_groups:
+        - name: standard
+          ami_release_version: 1.21.4-20211013
+          instance_types:
+            - t3a.small
+            - t3.small
+            - t2.small
+          scaling_config:
+            desired_size: 1
+            max_size: 2
+            min_size: 1
+        - name: high-memory
+          ami_type: AL2_ARM_64
+          ami_release_version: 1.21.4-20211013
+          instance_types:
+            - r6g.medium
+          labels:
+            high-memory: "true"
+          scaling_config:
+            desired_size: 0
+            max_size: 1
+            min_size: 0
       role_mappings:
         role_arns:
           - arn:aws:iam::593291632749:role/restricted-admin

--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -28,6 +28,10 @@ config:
             desired_size: 0
             max_size: 1
             min_size: 0
+          taints:
+            - effect: NO_SCHEDULE
+              key: high-memory
+              value: "true"
       role_mappings:
         role_arns:
           - arn:aws:iam::593291632749:role/restricted-admin

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -21,6 +21,7 @@ config:
         - name: high-memory
           ami_type: AL2_ARM_64
           ami_release_version: 1.21.4-20211013
+          capacity_type: ON_DEMAND
           instance_types:
             - r6g.4xlarge
           labels:

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -6,17 +6,29 @@ config:
   data-engineering-airflow:eks:
     cluster:
       kubernetes_version: "1.21"
-      node_group:
-        ami_release_version: 1.21.4-20211013
-        capacity_type: ON_DEMAND
-        instance_types:
-          - t3a.medium
-          - t3.medium
-          - t2.medium
-        scaling_config:
-          desired_size: 1
-          max_size: 25
-          min_size: 1
+      node_groups:
+        - name: standard
+          ami_release_version: 1.21.4-20211013
+          capacity_type: ON_DEMAND
+          instance_types:
+            - t3a.medium
+            - t3.medium
+            - t2.medium
+          scaling_config:
+            desired_size: 1
+            max_size: 25
+            min_size: 1
+        - name: high-memory
+          ami_type: AL2_ARM_64
+          ami_release_version: 1.21.4-20211013
+          instance_types:
+            - r6g.4xlarge
+          labels:
+            high-memory: "true"
+          scaling_config:
+            desired_size: 0
+            max_size: 1
+            min_size: 0
       role_mappings:
         role_arns:
           - arn:aws:iam::593291632749:role/restricted-admin

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -29,6 +29,10 @@ config:
             desired_size: 0
             max_size: 1
             min_size: 0
+          taints:
+            - effect: NO_SCHEDULE
+              key: high-memory
+              value: "true"
       role_mappings:
         role_arns:
           - arn:aws:iam::593291632749:role/restricted-admin

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ All infrastructure is defined in the `infra` directory:
 The `eks` directory contains all infrastructure related to EKS and Kubernetes:
 
 - `cluster.py` defines the cluster itself and a managed node group
-- `cluster_autoscaler.py` defines the cluster autoscaler Helm chart
+- `cluster_autoscaler.py` defines the Cluster Autoscaler Helm chart
 - `kube2iam.py` defines the kube2iam Helm chart
 - `namespaces/airflow.py` defines a namespace on the cluster in which Airflow
   can run pods
@@ -159,6 +159,12 @@ itself.
 This could lead to a situation where untagged EC2 instances are created between
 the time at which the managed node group (and autoscaling group) are created and
 the tags are added to the autoscaling group.
+
+## Reference
+
+- [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler)
+- [Gatekeeper](https://github.com/open-policy-agent/gatekeeper)
+- [kube2iam](https://github.com/jtblin/kube2iam)
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ The `iam` directory contains all infrastructure related to IAM:
   by nodes in the managed node group
 - `role_policies.py` defines the role policy for the execution role for Airflow
 
+## Node Groups
+
+TODO
+
 ## Tasks
 
 ### How to manually deploy or update an environment
@@ -99,8 +103,6 @@ config.
 The AMI release version should match the Kubernetes version. For example, if the
 Kubernetes version is `1.20`, you should specify an AMI release version with the
 tag `1.20.*-*`.
-
-###
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ To run tests manually, run:
 
 ## Notes
 
-Tags set on a managed node group are note automatically propagated to the
+Tags set on a managed node group are not automatically propagated to the
 provisioned autoscaling group and consquently are not applied to EC2 instances
 created by the autoscaling group.
 

--- a/infra/eks/cluster.py
+++ b/infra/eks/cluster.py
@@ -39,23 +39,39 @@ cluster = eks.Cluster(
     tags=tagger.create_tags(name=base_name),
 )
 
-node_group_config = cluster_config["node_group"]
+node_groups = cluster_config["node_groups"]
 
-nodeGroup = aws.eks.NodeGroup(
-    resource_name=base_name,
-    ami_type=node_group_config.get("ami_type", "AL2_x86_64"),
-    capacity_type=node_group_config.get("capacity_type", "SPOT"),
-    cluster_name=cluster.eks_cluster.name,
-    disk_size=node_group_config.get("disk_size", 20),
-    force_update_version=None,
-    instance_types=node_group_config["instance_types"],
-    node_group_name="airflow",
-    node_role_arn=instanceRole.arn,
-    release_version=node_group_config["ami_release_version"],
-    scaling_config=aws.eks.NodeGroupScalingConfigArgs(
-        **node_group_config["scaling_config"]
-    ),
-    subnet_ids=cluster.core.private_subnet_ids,
-    tags=tagger.create_tags("airflow"),
-    opts=ResourceOptions(parent=cluster),
-)
+for node_group in node_groups:
+    nodeGroup = aws.eks.NodeGroup(
+        resource_name=f"{base_name}-{node_group['name']}",
+        ami_type=node_group.get("ami_type", "AL2_x86_64"),
+        capacity_type=node_group.get("capacity_type", "SPOT"),
+        cluster_name=cluster.eks_cluster.name,
+        disk_size=node_group.get("disk_size", 20),
+        instance_types=node_group["instance_types"],
+        labels=node_group.get("labels"),
+        node_group_name=node_group["name"],
+        node_role_arn=instanceRole.arn,
+        release_version=node_group["ami_release_version"],
+        scaling_config=aws.eks.NodeGroupScalingConfigArgs(
+            **node_group["scaling_config"]
+        ),
+        subnet_ids=cluster.core.private_subnet_ids,
+        taints=None,  # TODO
+        tags=tagger.create_tags(f"{base_name}-{node_group['name']}"),
+        opts=ResourceOptions(parent=cluster),
+    )
+
+    for i, (key, value) in enumerate(node_group.get("labels", {}).items()):
+        aws.autoscaling.Tag(
+            resource_name=f"{base_name}-{node_group['name']}-{i}",
+            autoscaling_group_name=nodeGroup.resources.apply(
+                lambda x: x[0]["autoscaling_groups"][0]["name"]
+            ),
+            tag=aws.autoscaling.TagTagArgs(
+                key=f"k8s.io/cluster-autoscaler/node-template/label/{key}",
+                value=value,
+                propagate_at_launch=True,
+            ),
+            opts=ResourceOptions(parent=nodeGroup),
+        )

--- a/infra/eks/cluster_autoscaler.py
+++ b/infra/eks/cluster_autoscaler.py
@@ -17,6 +17,7 @@ release = k8s.helm.v3.Release(
         "autoDiscovery": {"clusterName": cluster.eks_cluster.name},
         "awsRegion": region,
         "fullnameOverride": "cluster-autoscaler",
+        "podAnnotations": {"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"},
     },
     version=eks_config["cluster_autoscaler"]["chart_version"],
     opts=ResourceOptions(


### PR DESCRIPTION
This PR will add a high-memory node group to each environment that can be selected for memory-intensive tasks, such as VIPER. This replicates functionality on the existing Kubernetes cluster.