### PR TITLE
kube2iam environment namespace restriction

### DIFF
--- a/infra/eks/airflow.py
+++ b/infra/eks/airflow.py
@@ -1,5 +1,6 @@
 import pulumi_kubernetes as k8s
 from pulumi import ResourceOptions
+import json
 
 from .cluster import cluster
 from .kube2iam import kube2iam
@@ -11,7 +12,7 @@ airflow_namespace = k8s.core.v1.Namespace(
     resource_name="airflow",
     metadata=k8s.meta.v1.ObjectMetaArgs(
         name="airflow",
-        annotations={"iam.amazonaws.com/allowed-roles": [f"airflow_{environment_name}"]},
+        annotations={"iam.amazonaws.com/allowed-roles": json.dumps([f"airflow_{environment_name}"])}
     ),
     opts=ResourceOptions(
         provider=cluster.provider, depends_on=[kube2iam], parent=cluster

--- a/infra/eks/airflow.py
+++ b/infra/eks/airflow.py
@@ -3,6 +3,7 @@ from pulumi import ResourceOptions
 
 from .cluster import cluster
 from .kube2iam import kube2iam
+from base import environment_name
 
 # See https://docs.aws.amazon.com/mwaa/latest/userguide/mwaa-eks-example.html
 
@@ -10,7 +11,7 @@ airflow_namespace = k8s.core.v1.Namespace(
     resource_name="airflow",
     metadata=k8s.meta.v1.ObjectMetaArgs(
         name="airflow",
-        annotations={"iam.amazonaws.com/allowed-roles": '["airflow*"]'},
+        annotations={"iam.amazonaws.com/allowed-roles": [f"airflow_{environment_name}"]},
     ),
     opts=ResourceOptions(
         provider=cluster.provider, depends_on=[kube2iam], parent=cluster

--- a/infra/eks/airflow.py
+++ b/infra/eks/airflow.py
@@ -1,10 +1,11 @@
-import pulumi_kubernetes as k8s
-from pulumi import ResourceOptions
 import json
 
+import pulumi_kubernetes as k8s
+from pulumi import ResourceOptions
+
+from ..base import environment_name
 from .cluster import cluster
 from .kube2iam import kube2iam
-from ..base import environment_name
 
 # See https://docs.aws.amazon.com/mwaa/latest/userguide/mwaa-eks-example.html
 

--- a/infra/eks/airflow.py
+++ b/infra/eks/airflow.py
@@ -3,7 +3,7 @@ from pulumi import ResourceOptions
 
 from .cluster import cluster
 from .kube2iam import kube2iam
-from base import environment_name
+from ..base import environment_name
 
 # See https://docs.aws.amazon.com/mwaa/latest/userguide/mwaa-eks-example.html
 

--- a/infra/eks/airflow.py
+++ b/infra/eks/airflow.py
@@ -12,7 +12,11 @@ airflow_namespace = k8s.core.v1.Namespace(
     resource_name="airflow",
     metadata=k8s.meta.v1.ObjectMetaArgs(
         name="airflow",
-        annotations={"iam.amazonaws.com/allowed-roles": json.dumps([f"airflow_{environment_name}"])}
+        annotations={
+            "iam.amazonaws.com/allowed-roles": json.dumps(
+                [f"airflow_{environment_name}*"]
+            )
+        },
     ),
     opts=ResourceOptions(
         provider=cluster.provider, depends_on=[kube2iam], parent=cluster


### PR DESCRIPTION
Update kube2iam namespace restrictions so roles can only be used in the correct environment

Add base.environment_name as f string variable to replace wildcard.