### PR TITLE
Enable all cluster log types

### DIFF
--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -72,4 +72,4 @@ jobs:
           PULUMI_CONFIG_PASSPHRASE: ""
         run: |
           pulumi stack select -c ${{ matrix.stack }}
-          pulumi preview --refresh --diff
+          pulumi preview --refresh

--- a/infra/eks/cluster.py
+++ b/infra/eks/cluster.py
@@ -28,6 +28,13 @@ for role_arn in cluster_config["role_mappings"]["role_arns"]:
 cluster = eks.Cluster(
     resource_name=base_name,
     create_oidc_provider=True,
+    enabled_cluster_log_types=[
+        "api",
+        "audit",
+        "authenticator",
+        "controllerManager",
+        "scheduler",
+    ],
     instance_role=instanceRole,
     name=base_name,
     private_subnet_ids=[private_subnet.id for private_subnet in private_subnets],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 data-engineering-pulumi-components>=0.1.0.dev2,<1.0.0
-pulumi>=3.0.0,<4.0.0
+pulumi>=3.0.0,<3.23.0
 pulumi-aws>=4.0.0,<5.0.0
 pulumi-eks>=0.30.0,<1.0.0
 pulumi-kubernetes>=3.7.0,<=4.0.0


### PR DESCRIPTION
This PR will enable all types of cluster logging. In line with the CIS Amazon EKS Benchmark 2.1.1.