### PR TITLE
Update to mojap-airflow-tools v2.1.0

### DIFF
--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -52,7 +52,7 @@ config:
       --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.0.2/constraints-3.7.txt"
       apache-airflow[cncf.kubernetes]
       kubernetes
-      mojap-airflow-tools==2.0.1
+      mojap-airflow-tools==2.1.0
   data-engineering-airflow:vpc:
     cidr_block: 10.192.0.0/16
     private_subnets:

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -54,7 +54,7 @@ config:
       --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.0.2/constraints-3.7.txt"
       apache-airflow[cncf.kubernetes]
       kubernetes
-      mojap-airflow-tools==2.0.1
+      mojap-airflow-tools==2.1.0
   data-engineering-airflow:vpc:
     cidr_block: 10.194.0.0/16
     private_subnets:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 data-engineering-pulumi-components>=0.1.0.dev2,<1.0.0
-pulumi>=3.0.0,<4.0.0
+pulumi>=3.0.0,<3.23.0
 pulumi-aws>=4.0.0,<5.0.0
 pulumi-eks>=0.30.0,<1.0.0
 pulumi-kubernetes>=3.7.0,<=4.0.0


### PR DESCRIPTION
This PR will use `mojap-airflow-tools` v2.1.0 in the dev and prod environments.