### PR TITLE
Mitigate issue with providers

### DIFF
--- a/infra/eks/airflow.py
+++ b/infra/eks/airflow.py
@@ -4,7 +4,7 @@ import pulumi_kubernetes as k8s
 from pulumi import ResourceOptions
 
 from ..base import environment_name
-from .cluster import cluster
+from .cluster import cluster, cluster_provider
 from .kube2iam import kube2iam
 
 # See https://docs.aws.amazon.com/mwaa/latest/userguide/mwaa-eks-example.html
@@ -20,7 +20,7 @@ airflow_namespace = k8s.core.v1.Namespace(
         },
     ),
     opts=ResourceOptions(
-        provider=cluster.provider, depends_on=[kube2iam], parent=cluster
+        provider=cluster_provider, depends_on=[kube2iam], parent=cluster
     ),
 )
 
@@ -45,7 +45,7 @@ role = k8s.rbac.v1.Role(
             verbs=["create", "describe", "delete", "get", "list", "patch", "update"],
         )
     ],
-    opts=ResourceOptions(provider=cluster.provider, parent=cluster),
+    opts=ResourceOptions(provider=cluster_provider, parent=cluster),
 )
 
 roleBinding = k8s.rbac.v1.RoleBinding(
@@ -57,5 +57,5 @@ roleBinding = k8s.rbac.v1.RoleBinding(
     role_ref=k8s.rbac.v1.RoleRefArgs(
         api_group="rbac.authorization.k8s.io", kind="Role", name="mwaa-role"
     ),
-    opts=ResourceOptions(provider=cluster.provider, parent=cluster),
+    opts=ResourceOptions(provider=cluster_provider, parent=cluster),
 )

--- a/infra/eks/cluster.py
+++ b/infra/eks/cluster.py
@@ -1,5 +1,8 @@
+import json
+
 import pulumi_aws as aws
 import pulumi_eks as eks
+import pulumi_kubernetes as k8s
 from pulumi import ResourceOptions
 
 from ..base import base_name, caller_arn, eks_config, tagger
@@ -44,6 +47,11 @@ cluster = eks.Cluster(
     version=str(cluster_config["kubernetes_version"]),
     vpc_id=vpc.id,
     tags=tagger.create_tags(name=base_name),
+)
+
+cluster_provider = k8s.Provider(
+    resource_name=base_name,
+    kubeconfig=cluster.kubeconfig.apply(lambda kubeconfig: json.dumps(kubeconfig)),
 )
 
 node_groups = cluster_config["node_groups"]

--- a/infra/eks/cluster_autoscaler.py
+++ b/infra/eks/cluster_autoscaler.py
@@ -2,8 +2,8 @@ import pulumi_kubernetes as k8s
 from pulumi import ResourceOptions
 
 from ..base import eks_config, region
-from .cluster import cluster
 from ..iam.roles import clusterAutoscalerRole
+from .cluster import cluster, cluster_provider
 
 cluster_autoscaler_namespace = k8s.core.v1.Namespace(
     resource_name="cluster-autoscaler-system",
@@ -15,7 +15,7 @@ cluster_autoscaler_namespace = k8s.core.v1.Namespace(
             )
         },
     ),
-    opts=ResourceOptions(provider=cluster.provider, parent=cluster),
+    opts=ResourceOptions(provider=cluster_provider, parent=cluster),
 )
 
 clusterAutoscaler = k8s.helm.v3.Release(
@@ -39,7 +39,7 @@ clusterAutoscaler = k8s.helm.v3.Release(
     },
     version=eks_config["cluster_autoscaler"]["chart_version"],
     opts=ResourceOptions(
-        provider=cluster.provider,
+        provider=cluster_provider,
         parent=cluster,
     ),
 )

--- a/infra/eks/kube2iam.py
+++ b/infra/eks/kube2iam.py
@@ -3,7 +3,7 @@ from pulumi.resource import ResourceOptions
 
 from ..base import eks_config, region
 from ..iam.roles import defaultRole, instanceRole
-from .cluster import cluster
+from .cluster import cluster, cluster_provider
 
 kube2iam_namespace = k8s.core.v1.Namespace(
     resource_name="kube2iam-system",
@@ -11,7 +11,7 @@ kube2iam_namespace = k8s.core.v1.Namespace(
         name="kube2iam-system",
         annotations={"iam.amazonaws.com/allowed-roles": '["*"]'},
     ),
-    opts=ResourceOptions(provider=cluster.provider, parent=cluster),
+    opts=ResourceOptions(provider=cluster_provider, parent=cluster),
 )
 
 kube2iam = k8s.helm.v3.Release(
@@ -38,7 +38,7 @@ kube2iam = k8s.helm.v3.Release(
     },
     version=eks_config["kube2iam"]["chart_version"],
     opts=ResourceOptions(
-        provider=cluster.provider,
+        provider=cluster_provider,
         parent=cluster,
     ),
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 data-engineering-pulumi-components>=0.1.0.dev2,<1.0.0
-pulumi>=3.0.0,<3.23.0
+pulumi>=3.0.0,<4.0.0
 pulumi-aws>=4.0.0,<5.0.0
 pulumi-eks>=0.30.0,<1.0.0
 pulumi-kubernetes>=3.7.0,<=4.0.0


### PR DESCRIPTION
This PR will use a new `pulumi_kubernetes.Provider` resource in place of the existing `cluster.provider`. This will mitigate issues present since Pulumi v3.23.0.