### PR TITLE
Enable SSM Agent on worker nodes

### DIFF
--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -8,7 +8,7 @@ config:
       kubernetes_version: "1.21"
       node_groups:
         - name: standard
-          ami_release_version: 1.21.5-20220112
+          ami_release_version: 1.21.5-20220216
           instance_types:
             - t3a.small
             - t3.small
@@ -19,7 +19,7 @@ config:
             min_size: 1
         - name: high-memory
           ami_type: AL2_ARM_64
-          ami_release_version: 1.21.5-20220112
+          ami_release_version: 1.21.5-20220216
           instance_types:
             - r6g.medium
           labels:

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -8,7 +8,7 @@ config:
       kubernetes_version: "1.21"
       node_groups:
         - name: standard
-          ami_release_version: 1.21.5-20220112
+          ami_release_version: 1.21.5-20220216
           capacity_type: ON_DEMAND
           instance_types:
             - t3a.medium
@@ -20,7 +20,7 @@ config:
             min_size: 1
         - name: high-memory
           ami_type: AL2_ARM_64
-          ami_release_version: 1.21.5-20220112
+          ami_release_version: 1.21.5-20220216
           capacity_type: ON_DEMAND
           instance_types:
             - r6g.4xlarge

--- a/infra/iam/roles.py
+++ b/infra/iam/roles.py
@@ -55,6 +55,7 @@ instanceRole = Role(
             arn="arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
         ).arn,
         get_policy(arn="arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy").arn,
+        get_policy(arn="arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore").arn,
     ],
     name=f"{base_name}-node-instance-role",
     tags=tagger.create_tags(f"{base_name}-node-instance-role"),


### PR DESCRIPTION
This PR will enable SSM Agent on Kubernetes worker nodes.

It will also update worker nodes to use the latest Amazon-managed AMI.