### PR TITLE
PDE-1538 update CIDR remove gatekeeper upgrade airflow version

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -46,24 +46,26 @@ config:
     kube2iam:
       chart_version: 2.6.0
   data-engineering-airflow:mwaa:
-    airflow_version: 2.0.2
+    airflow_version: 2.2.2
     environment_class: mw1.medium
     max_workers: 10
     min_workers: 1
     requirements: |
-      --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.0.2/constraints-3.7.txt"
+      --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.2.2/constraints-3.7.txt"
       apache-airflow[cncf.kubernetes]
       kubernetes
-      mojap-airflow-tools==2.1.0
   data-engineering-airflow:vpc:
-    cidr_block: 10.194.0.0/16
+    cidr_block: 10.201.0.0/16
+    transit_gateway:
+      name: moj
+      id: tgw-009e14703041026a5
     private_subnets:
       cidr_blocks:
-        - 10.194.20.0/24
-        - 10.194.21.0/24
-        - 10.194.22.0/24
+        - 10.201.20.0/24
+        - 10.201.21.0/24
+        - 10.201.22.0/24
     public_subnets:
       cidr_blocks:
-        - 10.194.10.0/24
-        - 10.194.11.0/24
-        - 10.194.12.0/24
+        - 10.201.10.0/24
+        - 10.201.11.0/24
+        - 10.201.12.0/24

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ To deploy or update an environment:
 
         pulumi up --refresh
 
+    If you get an error message about helm not being able to create resources, ignore and try to pulumi up again.
 ### How to upgrade the Kubernetes version
 
 For all available Kubernetes versions, see the
@@ -155,6 +156,11 @@ tag `1.20.*-*`.
 To run tests manually, run:
 
     python -m pytest tests/
+
+### How to attach alpha_users to the airflow UI Access policy
+
+Please run the following, amking sure to exec into the restricted-admin role in the data account first:
+    python scripts/attach_role_policies.py
 
 ## Notes
 

--- a/__main__.py
+++ b/__main__.py
@@ -1,5 +1,5 @@
 from infra import base, mwaa, s3, vpc
-from infra.eks import airflow, cluster, cluster_autoscaler, gatekeeper, kube2iam
+from infra.eks import airflow, cluster, cluster_autoscaler, kube2iam
 from infra.iam import policies, role_policies, roles
 
 __all__ = [
@@ -7,7 +7,7 @@ __all__ = [
     "base",
     "cluster",
     "cluster_autoscaler",
-    "gatekeeper",
+    # "gatekeeper",
     "kube2iam",
     "mwaa",
     "policies",


### PR DESCRIPTION
- Remove gatekeeper for now (gatekeeper will be re-introduced as part of PDE-1464)
- Add VPC Transit Gateway attachment
- Upgrade prod airflow version to 2.2.2
- Use new VPC CIDR range for prod