### PR TITLE
Update AMI version to 1.21.5-20220429

### DIFF
--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -8,7 +8,7 @@ config:
       kubernetes_version: "1.21"
       node_groups:
         - name: standard
-          ami_release_version: 1.21.5-20220216
+          ami_release_version: 1.21.5-20220429
           instance_types:
             - t3a.medium
             - t3.medium
@@ -18,7 +18,7 @@ config:
             max_size: 10
             min_size: 0
         - name: high-memory
-          ami_release_version: 1.21.5-20220216
+          ami_release_version: 1.21.5-20220429
           instance_types:
             - r6i.4xlarge
           labels:

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -8,7 +8,7 @@ config:
       kubernetes_version: "1.21"
       node_groups:
         - name: standard
-          ami_release_version: 1.21.5-20220216
+          ami_release_version: 1.21.5-20220429
           capacity_type: ON_DEMAND
           instance_types:
             - t3a.medium
@@ -19,7 +19,7 @@ config:
             max_size: 25
             min_size: 1
         - name: high-memory
-          ami_release_version: 1.21.5-20220216
+          ami_release_version: 1.21.5-20220429
           capacity_type: ON_DEMAND
           instance_types:
             - r6i.4xlarge


### PR DESCRIPTION
This PR will upgrade the AMI version for all nodes in prod and dev to 1.21.5-20220429.