### PR TITLE
Protect elastic IPs from accidental deletion

### DIFF
--- a/infra/vpc.py
+++ b/infra/vpc.py
@@ -149,7 +149,7 @@ for availability_zone, public_cidr_block, private_cidr_block in zip(
     for route in vpc_config["transit_gateway"]["routes"]:
         tgwPrivateRoute = Route(
             resource_name=f"{base_name}-private-{availability_zone}-{route['name']}",
-            destination_cidr_block=route['cidr_block'],
+            destination_cidr_block=route["cidr_block"],
             transit_gateway_id=transitGateway.id,
             route_table_id=privateRouteTable.id,
             opts=ResourceOptions(depends_on=transitGateway, parent=privateRouteTable),

--- a/infra/vpc.py
+++ b/infra/vpc.py
@@ -113,7 +113,9 @@ for availability_zone, public_cidr_block, private_cidr_block in zip(
         resource_name=f"{base_name}-{availability_zone}",
         vpc=True,
         tags=tagger.create_tags(f"{base_name}-{availability_zone}"),
-        opts=ResourceOptions(depends_on=[internetGateway], parent=internetGateway),
+        opts=ResourceOptions(
+            depends_on=[internetGateway], parent=internetGateway, protect=True
+        ),
     )
     natGateway = NatGateway(
         resource_name=f"{base_name}-{availability_zone}",

--- a/infra/vpc.py
+++ b/infra/vpc.py
@@ -1,5 +1,5 @@
-from email.mime import base
 from pulumi import ResourceOptions
+from pulumi_aws import get_availability_zones
 from pulumi_aws.ec2 import (
     Eip,
     InternetGateway,
@@ -12,8 +12,9 @@ from pulumi_aws.ec2 import (
     Subnet,
     Vpc,
 )
-from pulumi_aws import get_availability_zones, ec2transitgateway
-from .base import tagger, config, base_name, region
+from pulumi_aws.ec2transitgateway import TransitGateway, VpcAttachment
+
+from .base import base_name, config, tagger
 
 vpc_config = config.require_object("vpc")
 
@@ -32,7 +33,7 @@ internetGateway = InternetGateway(
     opts=ResourceOptions(parent=vpc),
 )
 
-transitGateway = ec2transitgateway.TransitGateway.get(
+transitGateway = TransitGateway.get(
     resource_name=vpc_config["transit_gateway"]["name"],
     id=vpc_config["transit_gateway"]["id"],
 )
@@ -147,7 +148,7 @@ for availability_zone, public_cidr_block, private_cidr_block in zip(
         opts=ResourceOptions(parent=privateRouteTable),
     )
     for route in vpc_config["transit_gateway"]["routes"]:
-        tgwPrivateRoute = Route(
+        transitGatewayPrivateRoute = Route(
             resource_name=f"{base_name}-private-{availability_zone}-{route['name']}",
             destination_cidr_block=route["cidr_block"],
             transit_gateway_id=transitGateway.id,
@@ -155,15 +156,15 @@ for availability_zone, public_cidr_block, private_cidr_block in zip(
             opts=ResourceOptions(depends_on=transitGateway, parent=privateRouteTable),
         )
 
-transitGatewayVpcAttachment = ec2transitgateway.VpcAttachment(
-    resource_name=f"{base_name}",
+transitGatewayVpcAttachment = VpcAttachment(
+    resource_name=base_name,
     dns_support="enable",
     subnet_ids=[private_subnet.id for private_subnet in private_subnets],
     transit_gateway_default_route_table_association=True,
     transit_gateway_default_route_table_propagation=True,
     transit_gateway_id=transitGateway.id,
     vpc_id=vpc.id,
-    tags=tagger.create_tags(f"{base_name}"),
+    tags=tagger.create_tags(base_name),
     opts=ResourceOptions(
         depends_on=[transitGateway].extend(private_subnets), parent=vpc
     ),


### PR DESCRIPTION
This PR adds protection to elastic IP addresses. This will prevent them from being accidentally deleted. This will ensure that they remain fixed for external services that need to whitelist them.

This PR also makes a number of small style and formatting changes.