### PR TITLE
Upgrade VPC CNI version

### DIFF
--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -23,9 +23,6 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           role-skip-session-tagging: true
           role-duration-seconds: 3600
-      - name: Get AWS CLI Version
-        run: |
-          aws --version
       - name: Remove existing Pulumi installations
         run: |
           rm -rf $HOME/.pulumi
@@ -50,6 +47,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
+      - name: Upgrade AWS CLI
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install --update
+          aws --version
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/setup-pulumi@v2
         with:
-          pulumi-version: 3.31.0
+          pulumi-version: ^3.0.0
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -23,6 +23,9 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           role-skip-session-tagging: true
           role-duration-seconds: 3600
+      - name: Get AWS CLI Version
+        run: |
+          aws --version
       - name: Remove existing Pulumi installations
         run: |
           rm -rf $HOME/.pulumi

--- a/.github/workflows/pulumi_up.yaml
+++ b/.github/workflows/pulumi_up.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/setup-pulumi@v2
         with:
-          pulumi-version: 3.31.0
+          pulumi-version: ^3.0.0
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pulumi_up.yaml
+++ b/.github/workflows/pulumi_up.yaml
@@ -47,6 +47,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
+      - name: Upgrade AWS CLI
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install --update
+          aws --version
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -40,7 +40,7 @@ config:
           - arn:aws:iam::042130406152:role/github-actions-runner
       vpc_cni_version: 1.11.2
     cluster_autoscaler:
-      chart_version: 9.10.7
+      chart_version: 9.19.1
     gatekeeper:
       chart_version: 3.6.0
     kube2iam:

--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -38,7 +38,9 @@ config:
           - arn:aws:iam::593291632749:role/restricted-admin
           - arn:aws:iam::189157455002:role/restricted-admin
           - arn:aws:iam::042130406152:role/github-actions-runner
-      vpc_cni_version: 1.11.2
+      vpc_cni:
+        image_version: 1.11.2
+        image_account_id: 602401143452
     cluster_autoscaler:
       chart_version: 9.19.1
     gatekeeper:

--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -38,7 +38,7 @@ config:
           - arn:aws:iam::593291632749:role/restricted-admin
           - arn:aws:iam::189157455002:role/restricted-admin
           - arn:aws:iam::042130406152:role/github-actions-runner
-      vpc_cni_version: 1.7.5
+      vpc_cni_version: 1.11.2
     cluster_autoscaler:
       chart_version: 9.10.7
     gatekeeper:

--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -36,6 +36,7 @@ config:
           - arn:aws:iam::593291632749:role/restricted-admin
           - arn:aws:iam::189157455002:role/restricted-admin
           - arn:aws:iam::042130406152:role/github-actions-runner
+      vpc_cni_version: 1.7.5
     cluster_autoscaler:
       chart_version: 9.10.7
     gatekeeper:

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -40,7 +40,7 @@ config:
           - arn:aws:iam::593291632749:role/restricted-admin
           - arn:aws:iam::189157455002:role/restricted-admin
           - arn:aws:iam::042130406152:role/github-actions-runner
-      vpc_cni_version: 1.7.5
+      vpc_cni_version: 1.11.2
     cluster_autoscaler:
       chart_version: 9.10.7
     gatekeeper:

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -42,7 +42,7 @@ config:
           - arn:aws:iam::042130406152:role/github-actions-runner
       vpc_cni_version: 1.11.2
     cluster_autoscaler:
-      chart_version: 9.10.7
+      chart_version: 9.19.1
     gatekeeper:
       chart_version: 3.6.0
     kube2iam:

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -38,6 +38,7 @@ config:
           - arn:aws:iam::593291632749:role/restricted-admin
           - arn:aws:iam::189157455002:role/restricted-admin
           - arn:aws:iam::042130406152:role/github-actions-runner
+      vpc_cni_version: 1.7.5
     cluster_autoscaler:
       chart_version: 9.10.7
     gatekeeper:

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -40,7 +40,9 @@ config:
           - arn:aws:iam::593291632749:role/restricted-admin
           - arn:aws:iam::189157455002:role/restricted-admin
           - arn:aws:iam::042130406152:role/github-actions-runner
-      vpc_cni_version: 1.11.2
+      vpc_cni:
+        image_version: 1.11.2
+        image_account_id: 602401143452
     cluster_autoscaler:
       chart_version: 9.19.1
     gatekeeper:

--- a/Pulumi.sandpit.yaml
+++ b/Pulumi.sandpit.yaml
@@ -40,7 +40,7 @@ config:
           - arn:aws:iam::042130406152:role/github-actions-runner
       vpc_cni_version: 1.11.2
     cluster_autoscaler:
-      chart_version: 9.10.7
+      chart_version: 9.19.1
     gatekeeper:
       chart_version: 3.6.0
     kube2iam:

--- a/Pulumi.sandpit.yaml
+++ b/Pulumi.sandpit.yaml
@@ -38,6 +38,7 @@ config:
           - arn:aws:iam::593291632749:role/restricted-admin
           - arn:aws:iam::189157455002:role/restricted-admin
           - arn:aws:iam::042130406152:role/github-actions-runner
+      vpc_cni_version: 1.7.5
     cluster_autoscaler:
       chart_version: 9.10.7
     gatekeeper:

--- a/Pulumi.sandpit.yaml
+++ b/Pulumi.sandpit.yaml
@@ -38,7 +38,9 @@ config:
           - arn:aws:iam::593291632749:role/restricted-admin
           - arn:aws:iam::189157455002:role/restricted-admin
           - arn:aws:iam::042130406152:role/github-actions-runner
-      vpc_cni_version: 1.11.2
+      vpc_cni:
+        image_version: 1.11.2
+        image_account_id: 602401143452
     cluster_autoscaler:
       chart_version: 9.19.1
     gatekeeper:

--- a/Pulumi.sandpit.yaml
+++ b/Pulumi.sandpit.yaml
@@ -38,7 +38,7 @@ config:
           - arn:aws:iam::593291632749:role/restricted-admin
           - arn:aws:iam::189157455002:role/restricted-admin
           - arn:aws:iam::042130406152:role/github-actions-runner
-      vpc_cni_version: 1.7.5
+      vpc_cni_version: 1.11.2
     cluster_autoscaler:
       chart_version: 9.10.7
     gatekeeper:

--- a/README.md
+++ b/README.md
@@ -18,18 +18,24 @@ To work with this repository, you must have the following installed:
 
 You should also:
 
-1.  Create a virtual environment:
+1. Create a virtual environment:
 
-        python -m venv venv
+   ```zsh
+   python -m venv venv
+   ```
 
-2.  Activate the environment:
+2. Activate the environment:
 
-        source venv/bin/activate
+   ```zsh
+   source venv/bin/activate
+   ```
 
-3.  Install dependencies:
+3. Install dependencies:
 
-        pip install -r requirements.txt
-        pip install -r requirements-dev.txt
+   ```zsh
+   pip install -r requirements.txt
+   pip install -r requirements-dev.txt
+   ```
 
 ## Structure
 
@@ -119,17 +125,25 @@ To deploy or update an environment:
 1.  Create an AWS Vault session with the `restricted-admin@data-engineering`
     role:
 
-         aws-vault exec -d 12h restricted-admin@data-engineering
+    ```zsh
+    aws-vault exec -d 12h restricted-admin@data-engineering
+    ```
 
 2.  Select the relevant stack, for example, `dev`:
 
-        pulumi stack select dev
+    ```zsh
+    pulumi stack select dev
+    ```
 
 3.  Update the stack:
 
-        pulumi up --refresh
+    ```zsh
+    pulumi up --refresh
+    ```
 
-    If you get an error message during the pulumi up, try to pulumi up again before debugging
+    If you get an error message during the update, try to run the update again
+    before debugging.
+
 ### How to upgrade the Kubernetes version
 
 For all available Kubernetes versions, see the
@@ -154,16 +168,33 @@ The AMI release version should match the Kubernetes version. For example, if the
 Kubernetes version is `1.20`, you should specify an AMI release version with the
 tag `1.20.*-*`.
 
+### How to upgrade the VPC CNI version
+
+For all available VPC CNI versions see the [GitHub releases](https://github.com/aws/amazon-vpc-cni-k8s/releases).
+
+To upgrade the VPC CNI version, change the value of the
+`eks.cluster.vpc_cni_version` field in the relevant Pulumi stack config.
+
 ### How to run tests
 
 To run tests manually, run:
 
-    python -m pytest tests/
+```zsh
+python -m pytest tests/
+```
 
-### How to attach alpha_users to the airflow UI Access policy
+### How to attach Airflow UI access policy to user roles
 
-Please run the following, amking sure to exec into the restricted-admin role in the data account first:
-    python scripts/attach_role_policies.py
+The Airflow UI access policy is automatically attached to all new users of the
+Analytical Platform via the Control Panel, so you should not normally need to
+run this script.
+
+To manually attach the policy to all users, assume the restricted admin role in
+the data account and run:
+
+```zsh
+python scripts/attach_role_policies.py
+```
 
 ## Notes
 
@@ -179,16 +210,19 @@ This could lead to a situation where untagged EC2 instances are created between
 the time at which the managed node group (and autoscaling group) are created and
 the tags are added to the autoscaling group.
 
-When creating a stack from new, you might need to run pulumi up multiple times because pulumi is unable
-to detect that resources were successfully created. Simply ignore the error message and try to pulumi up
-again. You might also need to refresh the pulumi stack. Only debug if the pulumi up fails again with the 
-same error message. Hence it is better to pulumi up locally first, and use the pulumi up github action as
-a confirmation that the change has been completed.
+When creating a stack from new, you might need to run `pulumi` up multiple times
+because Pulumi is unable to detect that resources were successfully created.
+Simply ignore the error message and try to `pulumi up` again. You might also
+need to refresh the pulumi stack. Only debug if the pulumi up fails again with
+the same error message. Hence it is better to pulumi up locally first, and use
+the `pulumi up` GitHub Action as a confirmation that the change has been
+completed.
 
-When creating a stack from new, the transit gateway attachment status will show as "Pending Acceptance" 
-and pulumi will fail to create the routes to the TGW. You will need to request the DSO team to accept 
-the transit gateway attachment. Once the state changes to "Available", you can run pulumi up again to 
-create the routes to the TGW.
+When creating a stack from new, the Transit Gateway (TGW) attachment status will
+show as "Pending Acceptance" and Pulumi will fail to create the routes to the
+TGW. You will need to request the DSO team to accept the TGW attachment. Once
+the state changes to "Available", you can run `pulumi up` again to create the
+routes to the TGW.
 
 ## Reference
 

--- a/infra/eks/cluster.py
+++ b/infra/eks/cluster.py
@@ -1,5 +1,3 @@
-import json
-
 import pulumi_aws as aws
 import pulumi_eks as eks
 from pulumi import ResourceOptions

--- a/infra/eks/cluster.py
+++ b/infra/eks/cluster.py
@@ -5,11 +5,12 @@ import pulumi_eks as eks
 from pulumi import ResourceOptions
 from pulumi_kubernetes import Provider
 
-from ..base import base_name, caller_arn, eks_config, tagger
+from ..base import base_name, caller_arn, eks_config, region, tagger
 from ..iam.roles import executionRole, instanceRole
 from ..vpc import private_subnets, vpc
 
 cluster_config = eks_config["cluster"]
+vpc_cni_config = cluster_config["vpc_cni"]
 
 role_mappings = [
     eks.RoleMappingArgs(
@@ -47,12 +48,12 @@ cluster = eks.Cluster(
     version=str(cluster_config["kubernetes_version"]),
     vpc_cni_options=eks.VpcCniOptionsArgs(
         init_image=(
-            f"602401143452.dkr.ecr.eu-west-1.amazonaws.com/"
-            f"amazon-k8s-cni-init:v{cluster_config['vpc_cni_version']}"
+            f"{vpc_cni_config['image_account_id']}.dkr.ecr.{region}.amazonaws.com/"
+            f"amazon-k8s-cni-init:v{vpc_cni_config['image_version']}"
         ),
         image=(
-            f"602401143452.dkr.ecr.eu-west-1.amazonaws.com/"
-            f"amazon-k8s-cni:v{cluster_config['vpc_cni_version']}"
+            f"{vpc_cni_config['image_account_id']}.dkr.ecr.{region}.amazonaws.com/"
+            f"amazon-k8s-cni:v{vpc_cni_config['image_version']}"
         ),
     ),
     vpc_id=vpc.id,

--- a/infra/eks/cluster.py
+++ b/infra/eks/cluster.py
@@ -1,3 +1,5 @@
+import json
+
 import pulumi_aws as aws
 import pulumi_eks as eks
 from pulumi import ResourceOptions
@@ -42,6 +44,16 @@ cluster = eks.Cluster(
     role_mappings=role_mappings,
     skip_default_node_group=True,
     version=str(cluster_config["kubernetes_version"]),
+    vpc_cni_options=eks.VpcCniOptionsArgs(
+        init_image=(
+            f"602401143452.dkr.ecr.us-west-2.amazonaws.com/"
+            f"amazon-k8s-cni-init:v{cluster_config['vpc_cni_version']}"
+        ),
+        image=(
+            f"602401143452.dkr.ecr.us-west-2.amazonaws.com/"
+            f"amazon-k8s-cni:v{cluster_config['vpc_cni_version']}"
+        ),
+    ),
     vpc_id=vpc.id,
     tags=tagger.create_tags(name=base_name),
 )

--- a/infra/eks/cluster.py
+++ b/infra/eks/cluster.py
@@ -1,6 +1,9 @@
+import json
+
 import pulumi_aws as aws
 import pulumi_eks as eks
 from pulumi import ResourceOptions
+from pulumi_kubernetes import Provider
 
 from ..base import base_name, caller_arn, eks_config, tagger
 from ..iam.roles import executionRole, instanceRole
@@ -54,6 +57,11 @@ cluster = eks.Cluster(
     ),
     vpc_id=vpc.id,
     tags=tagger.create_tags(name=base_name),
+)
+
+cluster_provider = Provider(
+    resource_name=base_name,
+    kubeconfig=cluster.kubeconfig.apply(lambda k: json.dumps(k)),
 )
 
 node_groups = cluster_config["node_groups"]

--- a/infra/eks/cluster.py
+++ b/infra/eks/cluster.py
@@ -44,11 +44,11 @@ cluster = eks.Cluster(
     version=str(cluster_config["kubernetes_version"]),
     vpc_cni_options=eks.VpcCniOptionsArgs(
         init_image=(
-            f"602401143452.dkr.ecr.us-west-2.amazonaws.com/"
+            f"602401143452.dkr.ecr.eu-west-1.amazonaws.com/"
             f"amazon-k8s-cni-init:v{cluster_config['vpc_cni_version']}"
         ),
         image=(
-            f"602401143452.dkr.ecr.us-west-2.amazonaws.com/"
+            f"602401143452.dkr.ecr.eu-west-1.amazonaws.com/"
             f"amazon-k8s-cni:v{cluster_config['vpc_cni_version']}"
         ),
     ),

--- a/infra/eks/gatekeeper.py
+++ b/infra/eks/gatekeeper.py
@@ -1,8 +1,7 @@
 from pathlib import Path
 
 import pulumi_kubernetes as k8s
-from pulumi import Alias
-from pulumi.resource import Alias, ResourceOptions
+from pulumi import Alias, ResourceOptions
 
 from ..base import eks_config
 from .cluster import cluster, cluster_provider

--- a/infra/eks/gatekeeper.py
+++ b/infra/eks/gatekeeper.py
@@ -2,21 +2,23 @@ from pathlib import Path
 
 import pulumi_kubernetes as k8s
 from pulumi import Alias
-from pulumi.resource import ResourceOptions
+from pulumi.resource import Alias, ResourceOptions
 
 from ..base import eks_config
-from .cluster import cluster
+from .cluster import cluster, cluster_provider
 from .cluster_autoscaler import cluster_autoscaler_namespace
 from .kube2iam import kube2iam_namespace
 
 # See https://github.com/open-policy-agent/gatekeeper-library/
 
-namespace = k8s.core.v1.Namespace(
+gatekeeper_namespace = k8s.core.v1.Namespace(
     resource_name="gatekeeper-system",
     metadata=k8s.meta.v1.ObjectMetaArgs(
         name="gatekeeper-system",
     ),
-    opts=ResourceOptions(provider=cluster.provider, parent=cluster),
+    opts=ResourceOptions(
+        provider=cluster_provider, delete_before_replace=True, parent=cluster
+    ),
 )
 
 gatekeeper = k8s.helm.v3.Release(
@@ -27,12 +29,14 @@ gatekeeper = k8s.helm.v3.Release(
         repo="https://open-policy-agent.github.io/gatekeeper/charts"
     ),
     name="gatekeeper",
-    namespace=namespace.metadata.name,
+    namespace=gatekeeper_namespace.metadata.name,
     skip_await=False,
     version=eks_config["gatekeeper"]["chart_version"],
     opts=ResourceOptions(
-        provider=cluster.provider,
-        parent=cluster,
+        provider=cluster_provider,
+        delete_before_replace=True,
+        parent=gatekeeper_namespace,
+        aliases=[Alias(parent=cluster)],
     ),
 )
 
@@ -41,7 +45,7 @@ excluded_namespaces = [
     "kube-system",
     cluster_autoscaler_namespace.metadata.name,
     kube2iam_namespace.metadata.name,
-    namespace.metadata.name,
+    gatekeeper_namespace.metadata.name,
 ]
 
 # Prevent privileged containers
@@ -75,7 +79,9 @@ privilegedTemplate = k8s.apiextensions.CustomResource(
             }
         ],
     },
-    opts=ResourceOptions(provider=cluster.provider, parent=gatekeeper),
+    opts=ResourceOptions(
+        provider=cluster_provider, delete_before_replace=True, parent=gatekeeper
+    ),
 )
 
 k8s.apiextensions.CustomResource(
@@ -89,7 +95,9 @@ k8s.apiextensions.CustomResource(
             "excludedNamespaces": excluded_namespaces,
         }
     },
-    opts=ResourceOptions(provider=cluster.provider, parent=privilegedTemplate),
+    opts=ResourceOptions(
+        provider=cluster_provider, delete_before_replace=True, parent=privilegedTemplate
+    ),
 )
 
 # Prevent privilege escalation containers
@@ -126,7 +134,8 @@ allowPrivilegeEscalationContainerTemplate = k8s.apiextensions.CustomResource(
         ],
     },
     opts=ResourceOptions(
-        provider=cluster.provider,
+        provider=cluster_provider,
+        delete_before_replace=True,
         parent=gatekeeper,
         aliases=[Alias(name="allow-privilege-escalation-template")],
     ),
@@ -146,7 +155,8 @@ k8s.apiextensions.CustomResource(
         }
     },
     opts=ResourceOptions(
-        provider=cluster.provider,
+        provider=cluster_provider,
+        delete_before_replace=True,
         parent=allowPrivilegeEscalationContainerTemplate,
         aliases=[Alias(name="allow-privilege-escalation-constraint")],
     ),
@@ -185,7 +195,9 @@ allowPrivilegeEscalationPodTemplate = k8s.apiextensions.CustomResource(
             }
         ],
     },
-    opts=ResourceOptions(provider=cluster.provider, parent=gatekeeper),
+    opts=ResourceOptions(
+        provider=cluster_provider, delete_before_replace=True, parent=gatekeeper
+    ),
 )
 
 k8s.apiextensions.CustomResource(
@@ -200,6 +212,8 @@ k8s.apiextensions.CustomResource(
         }
     },
     opts=ResourceOptions(
-        provider=cluster.provider, parent=allowPrivilegeEscalationPodTemplate
+        provider=cluster_provider,
+        delete_before_replace=True,
+        parent=allowPrivilegeEscalationPodTemplate,
     ),
 )

--- a/infra/eks/kube2iam.py
+++ b/infra/eks/kube2iam.py
@@ -1,9 +1,9 @@
 import pulumi_kubernetes as k8s
-from pulumi.resource import ResourceOptions
+from pulumi.resource import Alias, ResourceOptions
 
 from ..base import eks_config, region
 from ..iam.roles import defaultRole, instanceRole
-from .cluster import cluster
+from .cluster import cluster, cluster_provider
 
 kube2iam_namespace = k8s.core.v1.Namespace(
     resource_name="kube2iam-system",
@@ -11,7 +11,9 @@ kube2iam_namespace = k8s.core.v1.Namespace(
         name="kube2iam-system",
         annotations={"iam.amazonaws.com/allowed-roles": '["*"]'},
     ),
-    opts=ResourceOptions(provider=cluster.provider, parent=cluster),
+    opts=ResourceOptions(
+        provider=cluster_provider, delete_before_replace=True, parent=cluster
+    ),
 )
 
 kube2iam = k8s.helm.v3.Release(
@@ -39,7 +41,9 @@ kube2iam = k8s.helm.v3.Release(
     },
     version=eks_config["kube2iam"]["chart_version"],
     opts=ResourceOptions(
-        provider=cluster.provider,
-        parent=cluster,
+        provider=cluster_provider,
+        delete_before_replace=True,
+        parent=kube2iam_namespace,
+        aliases=[Alias(parent=cluster)],
     ),
 )

--- a/infra/iam/roles.py
+++ b/infra/iam/roles.py
@@ -100,6 +100,7 @@ clusterAutoscalerRole = Role(
                             "autoscaling:DescribeTags",
                             "autoscaling:SetDesiredCapacity",
                             "autoscaling:TerminateInstanceInAutoScalingGroup",
+                            "ec2:DescribeInstanceTypes",
                         ],
                         resources=["*"],
                     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-data-engineering-pulumi-components>=0.4.0.dev1,<0.5.0
+data-engineering-pulumi-components>=0.4.0.dev1,<1.0.0
 pulumi>=3.0.0,<4.0.0
 pulumi-aws>=5.0.0,<6.0.0
 pulumi-eks>=0.30.0,<1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-data-engineering-pulumi-components>=0.1.0.dev2,<1.0.0
-pulumi>=3.0.0,<3.23.0
-pulumi-aws>=4.0.0,<5.0.0
+data-engineering-pulumi-components>=0.4.0.dev1,<0.5.0
+pulumi>=3.0.0,<4.0.0
+pulumi-aws>=5.0.0,<6.0.0
 pulumi-eks>=0.30.0,<1.0.0
 pulumi-kubernetes>=3.7.0,<=4.0.0


### PR DESCRIPTION
This PR will upgrade the VPC CNI version from v1.7.5 to v1.11.2.

It will also upgrade to `pulumi_aws>=5.0.0,<6.0.0` and update the cluster autoscaler to the latest version.