### PR TITLE
Upgrade to Kubernetes 1.22 🚀

### DIFF
--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -53,6 +53,8 @@ jobs:
           unzip awscliv2.zip
           sudo ./aws/install --update
           aws --version
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v2.0
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -8,7 +8,7 @@ config:
       kubernetes_version: "1.22"
       node_groups:
         - name: standard
-          ami_release_version: 1.21.5-20220429
+          ami_release_version: 1.22.9-20220610
           instance_types:
             - t3a.large
             - t3.large
@@ -19,7 +19,7 @@ config:
             min_size: 0
           disk_size: 150
         - name: high-memory
-          ami_release_version: 1.21.5-20220429
+          ami_release_version: 1.22.9-20220610
           instance_types:
             - r6i.4xlarge
           labels:

--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -5,7 +5,7 @@ config:
   aws:region: eu-west-1
   data-engineering-airflow:eks:
     cluster:
-      kubernetes_version: "1.21"
+      kubernetes_version: "1.22"
       node_groups:
         - name: standard
           ami_release_version: 1.21.5-20220429

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -8,7 +8,7 @@ config:
       kubernetes_version: "1.22"
       node_groups:
         - name: standard
-          ami_release_version: 1.21.5-20220429
+          ami_release_version: 1.22.9-20220610
           capacity_type: ON_DEMAND
           instance_types:
             - t3a.large
@@ -20,7 +20,7 @@ config:
             min_size: 1
           disk_size: 150
         - name: high-memory
-          ami_release_version: 1.21.5-20220429
+          ami_release_version: 1.22.9-20220610
           capacity_type: ON_DEMAND
           instance_types:
             - r6i.4xlarge

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -5,7 +5,7 @@ config:
   aws:region: eu-west-1
   data-engineering-airflow:eks:
     cluster:
-      kubernetes_version: "1.21"
+      kubernetes_version: "1.22"
       node_groups:
         - name: standard
           ami_release_version: 1.21.5-20220429

--- a/Pulumi.sandpit.yaml
+++ b/Pulumi.sandpit.yaml
@@ -5,7 +5,7 @@ config:
   aws:region: eu-west-1
   data-engineering-airflow:eks:
     cluster:
-      kubernetes_version: "1.21"
+      kubernetes_version: "1.22"
       node_groups:
         - ami_release_version: 1.21.5-20220429
           instance_types:

--- a/Pulumi.sandpit.yaml
+++ b/Pulumi.sandpit.yaml
@@ -7,7 +7,7 @@ config:
     cluster:
       kubernetes_version: "1.22"
       node_groups:
-        - ami_release_version: 1.21.5-20220429
+        - ami_release_version: 1.22.9-20220610
           instance_types:
             - t3a.small
             - t3.small
@@ -18,7 +18,7 @@ config:
             max_size: 5
             min_size: 0
           disk_size: 20
-        - ami_release_version: 1.21.5-20220429
+        - ami_release_version: 1.22.9-20220610
           instance_types:
             - r6i.4xlarge
           labels:


### PR DESCRIPTION
This PR will:
- upgrade all clusters to Kubernetes 1.22
- upgrade all node groups to use the latest AMI
- unsure the self-hosted runners use the latest version of `kubectl`