### PR TITLE
PDE-1818 Update github actions to use OIDC provider

### DIFF
--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -19,6 +19,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
+      - name: Upgrade AWS CLI
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install --update
+          aws --version
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -31,16 +37,18 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.9"
-      - name: Create Pulumi.txt
-        run: touch pulumi.txt
+      - name: Install Pulumi CLI
+        uses: pulumi/setup-pulumi@v2
+        with:
+          pulumi-version: ^3.0.0
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install --upgrade -r requirements.txt; fi
-      - name: Pulumi Preview
-        uses: pulumi/actions@v3
+      - name: Preview changes
         env:
-          PULUMI_CONFIG_PASSPHRASE_FILE: "pulumi.txt"
-        with:
-          command: preview
-          stack-name: ${{ matrix.stack }}
+          PULUMI_CONFIG_PASSPHRASE: ""
+        run: |
+          pulumi stack ls
+          pulumi stack select -c ${{ matrix.stack }}
+          pulumi preview --refresh

--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -3,81 +3,44 @@ on:
   pull_request:
     branches:
       - main
-env:
-  AWS_ROLE_TO_ASSUME: arn:aws:iam::189157455002:role/github-actions-infrastructure
+permissions:
+  id-token: write
+  contents: read
 jobs:
-  get-stacks:
-    name: Get Stacks
-    runs-on: [self-hosted, management-infrastructure]
-    outputs:
-      STACKS: ${{ steps.get-stacks.outputs.STACKS }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
-          role-skip-session-tagging: true
-          role-duration-seconds: 3600
-      - name: Remove existing Pulumi installations
-        run: |
-          rm -rf $HOME/.pulumi
-      - name: Install Pulumi CLI
-        uses: moj-analytical-services/actions-setup-pulumi@main
-      - name: Get Stacks
-        id: get-stacks
-        run: |
-          echo "::set-output name=STACKS::$(find Pulumi.*.yaml | sed -ne "s/Pulumi\.\(.*\)\.yaml/\1/p" | jq --raw-input -cs 'split("\n") | map(select(. != ""))')"
-        env:
-          PULUMI_CONFIG_PASSPHRASE: ""
-  preview-stack:
-    name: Preview Stack
-    needs: get-stacks
-    runs-on: [self-hosted, management-infrastructure]
+  preview:
+    name: Pulumi Preview
+    runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      max-parallel: 4
       matrix:
-        stack: ${{ fromJson(needs.get-stacks.outputs.STACKS) }}
+        stack: [prod, dev, sandpit]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - name: Upgrade AWS CLI
-        run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          sudo ./aws/install --update
-          aws --version
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-region: eu-west-1
-          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
+          role-to-assume: arn:aws:iam::593291632749:role/data-engineering-airflow-deployer
+          role-session-name: githubaction
           role-skip-session-tagging: true
           role-duration-seconds: 3600
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: "3.9"
-      - name: Remove existing Pulumi installations
-        run: |
-          rm -rf $HOME/.pulumi
-      - name: Install Pulumi CLI
-        uses: pulumi/setup-pulumi@v2
-        with:
-          pulumi-version: ^3.0.0
+      - name: Create Pulumi.txt
+        run: touch pulumi.txt
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install --upgrade -r requirements.txt; fi
-      - name: Preview changes
+      - name: Pulumi Preview
+        uses: pulumi/actions@v3
         env:
-          PULUMI_CONFIG_PASSPHRASE: ""
-        run: |
-          pulumi stack select -c ${{ matrix.stack }}
-          pulumi preview --refresh
+          PULUMI_CONFIG_PASSPHRASE_FILE: "pulumi.txt"
+        with:
+          command: preview
+          stack-name: ${{ matrix.stack }}

--- a/.github/workflows/pulumi_up.yaml
+++ b/.github/workflows/pulumi_up.yaml
@@ -1,83 +1,46 @@
-name: Pulumi Update
+name: Pulumi Preview
 on:
   push:
     branches:
       - main
-env:
-  AWS_ROLE_TO_ASSUME: arn:aws:iam::189157455002:role/github-actions-infrastructure
+permissions:
+  id-token: write
+  contents: read
 jobs:
-  get-stacks:
-    name: Get Stacks
-    runs-on: [self-hosted, management-infrastructure]
-    outputs:
-      STACKS: ${{ steps.get-stacks.outputs.STACKS }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
-          role-skip-session-tagging: true
-          role-duration-seconds: 3600
-      - name: Remove existing Pulumi installations
-        run: |
-          rm -rf $HOME/.pulumi
-      - name: Install Pulumi CLI
-        uses: pulumi/setup-pulumi@v2
-      - name: Get Stacks
-        id: get-stacks
-        run: |
-          echo "::set-output name=STACKS::$(find Pulumi.*.yaml | sed -ne "s/Pulumi\.\(.*\)\.yaml/\1/p" | jq --raw-input -cs 'split("\n") | map(select(. != ""))')"
-        env:
-          PULUMI_CONFIG_PASSPHRASE: ""
-  update-stack:
-    name: Update Stack
-    needs: get-stacks
-    runs-on: [self-hosted, management-infrastructure]
+  preview:
+    name: Pulumi Preview
+    runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      max-parallel: 4
       matrix:
-        stack: ${{ fromJson(needs.get-stacks.outputs.STACKS) }}
+        stack: [prod, dev, sandpit]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - name: Upgrade AWS CLI
-        run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          sudo ./aws/install --update
-          aws --version
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-region: eu-west-1
-          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
+          role-to-assume: arn:aws:iam::593291632749:role/data-engineering-airflow-deployer
+          role-session-name: githubaction
           role-skip-session-tagging: true
           role-duration-seconds: 3600
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: "3.9"
-      - name: Remove existing Pulumi installations
-        run: |
-          rm -rf $HOME/.pulumi
-      - name: Install Pulumi CLI
-        uses: pulumi/setup-pulumi@v2
-        with:
-          pulumi-version: ^3.0.0
+      - name: Create Pulumi.txt
+        run: touch pulumi.txt
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install --upgrade -r requirements.txt; fi
-      - name: Deploy changes
+      - name: Pulumi Up
+        uses: pulumi/actions@v3
         env:
-          PULUMI_CONFIG_PASSPHRASE: ""
-        run: |
-          pulumi stack select -c ${{ matrix.stack }}
-          pulumi up --refresh --yes --skip-preview
+          PULUMI_CONFIG_PASSPHRASE_FILE: "pulumi.txt"
+        with:
+          command: up
+          stack-name: ${{ matrix.stack }}

--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -1,7 +1,7 @@
 encryptionsalt: v1:T9q7uDyEaE0=:v1:yF6EMYWiihI5gpmw:M76o4sQ9SL8p439+H+YJCbm44nEqXg==
 config:
   aws:assume_role:
-    role_arn: arn:aws:iam::593291632749:role/data-engineering-infrastructure
+    role_arn: arn:aws:iam::593291632749:role/data-engineering-airflow-deployer
   aws:region: eu-west-1
   data-engineering-airflow:eks:
     cluster:
@@ -37,7 +37,7 @@ config:
         role_arns:
           - arn:aws:iam::593291632749:role/restricted-admin
           - arn:aws:iam::189157455002:role/restricted-admin
-          - arn:aws:iam::042130406152:role/github-actions-runner
+          - arn:aws:iam::593291632749:role/data-engineering-airflow-deployer
       vpc_cni:
         image_version: 1.11.2
         image_account_id: 602401143452

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -1,7 +1,7 @@
 encryptionsalt: v1:POsrlyZRcWk=:v1:l8SFSiBTf92aAScU:Sn/erZqPKSD1DAittO0G6DvEvRnLig==
 config:
   aws:assume_role:
-    role_arn: arn:aws:iam::593291632749:role/data-engineering-infrastructure
+    role_arn: arn:aws:iam::593291632749:role/data-engineering-airflow-deployer
   aws:region: eu-west-1
   data-engineering-airflow:eks:
     cluster:
@@ -39,7 +39,7 @@ config:
         role_arns:
           - arn:aws:iam::593291632749:role/restricted-admin
           - arn:aws:iam::189157455002:role/restricted-admin
-          - arn:aws:iam::042130406152:role/github-actions-runner
+          - arn:aws:iam::593291632749:role/data-engineering-airflow-deployer
       vpc_cni:
         image_version: 1.11.2
         image_account_id: 602401143452

--- a/Pulumi.sandpit.yaml
+++ b/Pulumi.sandpit.yaml
@@ -1,7 +1,7 @@
 encryptionsalt: v1:4PZXFHNMW5A=:v1:MYFVluz1XgI5A5YD:pKaRb1FH7lxJhI9YPdKmq59rgq1quA==
 config:
   aws:assume_role:
-    role_arn: arn:aws:iam::593291632749:role/data-engineering-infrastructure
+    role_arn: arn:aws:iam::593291632749:role/data-engineering-airflow-deployer
   aws:region: eu-west-1
   data-engineering-airflow:eks:
     cluster:
@@ -37,7 +37,7 @@ config:
         role_arns:
           - arn:aws:iam::593291632749:role/restricted-admin
           - arn:aws:iam::189157455002:role/restricted-admin
-          - arn:aws:iam::042130406152:role/github-actions-runner
+          - arn:aws:iam::593291632749:role/data-engineering-airflow-deployer
       vpc_cni:
         image_version: 1.11.2
         image_account_id: 602401143452


### PR DESCRIPTION
This PR rewrites our github actions to all run on Github Hardware.

**POTENTIAL ISSUES**:
I think I have given the runner all the permissions it should need, but at the same time I may have missed some. As such, this may break if there is a permission this role lacks. In that event, we will update the IAM policy file to give it the extra permissions, which is an easy fix.