### PR TITLE
Pde 1797/add smtp mwaa

### DIFF
--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -57,10 +57,7 @@ config:
       apache-airflow[cncf.kubernetes]
       kubernetes
       mojap-airflow-tools==2.2.1
-    smtp:
-      smtp_host: email-smtp
-      smtp_port: 587
-      smtp_mail_from: dataengineering@digital.justice.gov.uk
+    smtp_mail_from: dataengineering@digital.justice.gov.uk
   data-engineering-airflow:vpc:
     cidr_block: 10.200.0.0/16
     transit_gateway:

--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -58,7 +58,7 @@ config:
       kubernetes
       mojap-airflow-tools==2.2.1
     smtp:
-      smtp_host: email-smtp.eu-west-1.amazonaws.com
+      smtp_host: email-smtp
       smtp_port: 587
       smtp_mail_from: dataengineering@digital.justice.gov.uk
   data-engineering-airflow:vpc:

--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -57,6 +57,10 @@ config:
       apache-airflow[cncf.kubernetes]
       kubernetes
       mojap-airflow-tools==2.2.1
+    smtp:
+      smtp_host: email-smtp.eu-west-1.amazonaws.com
+      smtp_port: 587
+      smtp_mail_from: dataengineering@digital.justice.gov.uk
   data-engineering-airflow:vpc:
     cidr_block: 10.200.0.0/16
     transit_gateway:

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -59,6 +59,10 @@ config:
       apache-airflow[cncf.kubernetes]
       kubernetes
       mojap-airflow-tools==2.2.1
+    smtp:
+      smtp_host: email-smtp.eu-west-1.amazonaws.com
+      smtp_port: 587
+      smtp_mail_from: dataengineering@digital.justice.gov.uk
   data-engineering-airflow:vpc:
     cidr_block: 10.201.0.0/16
     transit_gateway:

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -60,7 +60,7 @@ config:
       kubernetes
       mojap-airflow-tools==2.2.1
     smtp:
-      smtp_host: email-smtp.eu-west-1.amazonaws.com
+      smtp_host: email-smtp
       smtp_port: 587
       smtp_mail_from: dataengineering@digital.justice.gov.uk
   data-engineering-airflow:vpc:

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -59,10 +59,7 @@ config:
       apache-airflow[cncf.kubernetes]
       kubernetes
       mojap-airflow-tools==2.2.1
-    smtp:
-      smtp_host: email-smtp
-      smtp_port: 587
-      smtp_mail_from: dataengineering@digital.justice.gov.uk
+    smtp_mail_from: dataengineering@digital.justice.gov.uk
   data-engineering-airflow:vpc:
     cidr_block: 10.201.0.0/16
     transit_gateway:

--- a/Pulumi.sandpit.yaml
+++ b/Pulumi.sandpit.yaml
@@ -57,6 +57,10 @@ config:
       apache-airflow[cncf.kubernetes]
       kubernetes
       mojap-airflow-tools==2.2.1
+    smtp:
+      smtp_host: email-smtp.eu-west-1.amazonaws.com
+      smtp_port: 587
+      smtp_mail_from: dataengineering@digital.justice.gov.uk
   data-engineering-airflow:vpc:
     cidr_block: 10.202.0.0/16
     private_subnets:

--- a/Pulumi.sandpit.yaml
+++ b/Pulumi.sandpit.yaml
@@ -57,10 +57,7 @@ config:
       apache-airflow[cncf.kubernetes]
       kubernetes
       mojap-airflow-tools==2.2.1
-    smtp:
-      smtp_host: email-smtp
-      smtp_port: 587
-      smtp_mail_from: dataengineering@digital.justice.gov.uk
+    smtp_mail_from: dataengineering@digital.justice.gov.uk
   data-engineering-airflow:vpc:
     cidr_block: 10.202.0.0/16
     private_subnets:

--- a/Pulumi.sandpit.yaml
+++ b/Pulumi.sandpit.yaml
@@ -58,7 +58,7 @@ config:
       kubernetes
       mojap-airflow-tools==2.2.1
     smtp:
-      smtp_host: email-smtp.eu-west-1.amazonaws.com
+      smtp_host: email-smtp
       smtp_port: 587
       smtp_mail_from: dataengineering@digital.justice.gov.uk
   data-engineering-airflow:vpc:

--- a/README.md
+++ b/README.md
@@ -198,10 +198,9 @@ python scripts/attach_role_policies.py
 
 ## Email Notifications
 
-We use AWS Simple Email Service (SES) for email notifications.
+We use Amazon Simple Email Service (SES) for email notifications.
 
-We use `dataengineering@digital.justice.gov.uk` as the "from" email address. This email address has been added as a verified identity to the data account without assigning a default configuration set:
-https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html#verify-email-addresses-procedure
+We use `dataengineering@digital.justice.gov.uk` as the "from" email address. This email address has been added as a verified identity to the data account without assigning a default configuration set. See [verify-email-addresses-procedure](https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html#verify-email-addresses-procedure) for more details.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,13 @@ the data account and run:
 python scripts/attach_role_policies.py
 ```
 
+## Email Notifications
+
+We use AWS Simple Email Service (SES) for email notifications.
+
+We use `dataengineering@digital.justice.gov.uk` as the "from" email address. This email address has been added as a verified identity to the data account without assigning a default configuration set:
+https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html#verify-email-addresses-procedure
+
 ## Notes
 
 Tags set on a managed node group are not automatically propagated to the

--- a/infra/iam/roles.py
+++ b/infra/iam/roles.py
@@ -1,4 +1,4 @@
-from pulumi.resource import ResourceOptions
+from pulumi import ResourceOptions
 from pulumi_aws.iam import (
     GetPolicyDocumentStatementArgs,
     GetPolicyDocumentStatementConditionArgs,

--- a/infra/iam/smtp_user.py
+++ b/infra/iam/smtp_user.py
@@ -1,27 +1,27 @@
 from pulumi_aws.iam import (
-    User,
     AccessKey,
-    Policy,
-    UserPolicyAttachment,
     get_policy_document,
     GetPolicyDocumentStatementArgs,
+    Policy,
+    User,
+    UserPolicyAttachment,
 )
 from pulumi.resource import ResourceOptions
 
 from ..base import base_name, tagger
 
 # create an IAM user who can send emails via SES
-smtp_user = User(
+smtpUser = User(
     resource_name=f"{base_name}-smtp-user",
     name=f"{base_name}-smtp-user",
     tags=tagger.create_tags(f"{base_name}-execution-role"),
 )
 
 # create an access key, which will form the SMTP user/pass
-access_key = AccessKey(
+accessKey = AccessKey(
     resource_name="access_key",
-    user=smtp_user.name,
-    opts=ResourceOptions(parent=smtp_user),
+    user=smtpUser.name,
+    opts=ResourceOptions(parent=smtpUser),
 )
 
 # allow the user to send emails
@@ -39,13 +39,13 @@ policy = Policy(
         ]
     ).json,
     tags=tagger.create_tags(f"{base_name}-ses-policy"),
-    opts=ResourceOptions(parent=smtp_user),
+    opts=ResourceOptions(parent=smtpUser),
 )
 
 # finally attach the policy to the user so it can send emails
 UserPolicyAttachment(
     resource_name="smtp",
-    user=smtp_user.name,
+    user=smtpUser.name,
     policy_arn=policy.arn,
-    opts=ResourceOptions(parent=smtp_user),
+    opts=ResourceOptions(parent=smtpUser),
 )

--- a/infra/iam/smtp_user.py
+++ b/infra/iam/smtp_user.py
@@ -1,0 +1,34 @@
+import pulumi_aws as aws
+import json
+
+from ..base import base_name, tagger
+
+# create an IAM user who can send emails via SES
+smtp_user = aws.iam.User(f"{base_name}-smtp-user",
+                         name=f"{base_name}-smtp-user",
+                         tags=tagger.create_tags(f"{base_name}-execution-role"),
+                         )
+
+# create an access key, which will form the SMTP user/pass
+access_key = aws.iam.AccessKey("access_key", user=smtp_user.name)
+
+# allow the user to send emails
+# note: we can reduce the scope here if we wanted
+policy = aws.iam.Policy(
+    "ses-policy",
+    name=f"{base_name}-ses-policy",
+    policy=json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Action": ["ses:SendRawEmail"], "Effect": "Allow", "Resource": "*"}
+            ],
+        }
+    ),
+    tags=tagger.create_tags(f"{base_name}-ses-policy"),
+)
+
+# finally attach the policy to the user so it can send emails
+aws.iam.UserPolicyAttachment(
+    "smtp", user=smtp_user.name, policy_arn=policy.arn,
+)

--- a/infra/iam/smtp_user.py
+++ b/infra/iam/smtp_user.py
@@ -1,34 +1,51 @@
-import pulumi_aws as aws
-import json
+from pulumi_aws.iam import (
+    User,
+    AccessKey,
+    Policy,
+    UserPolicyAttachment,
+    get_policy_document,
+    GetPolicyDocumentStatementArgs,
+)
+from pulumi.resource import ResourceOptions
 
 from ..base import base_name, tagger
 
 # create an IAM user who can send emails via SES
-smtp_user = aws.iam.User(f"{base_name}-smtp-user",
-                         name=f"{base_name}-smtp-user",
-                         tags=tagger.create_tags(f"{base_name}-execution-role"),
-                         )
+smtp_user = User(
+    resource_name=f"{base_name}-smtp-user",
+    name=f"{base_name}-smtp-user",
+    tags=tagger.create_tags(f"{base_name}-execution-role"),
+)
 
 # create an access key, which will form the SMTP user/pass
-access_key = aws.iam.AccessKey("access_key", user=smtp_user.name)
+access_key = AccessKey(
+    resource_name="access_key",
+    user=smtp_user.name,
+    opts=ResourceOptions(parent=smtp_user),
+)
 
 # allow the user to send emails
 # note: we can reduce the scope here if we wanted
-policy = aws.iam.Policy(
-    "ses-policy",
+policy = Policy(
+    resource_name=f"{base_name}-ses-policy",
     name=f"{base_name}-ses-policy",
-    policy=json.dumps(
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                {"Action": ["ses:SendRawEmail"], "Effect": "Allow", "Resource": "*"}
-            ],
-        }
-    ),
+    policy=get_policy_document(
+        statements=[
+            GetPolicyDocumentStatementArgs(
+                actions=["ses:SendRawEmail"],
+                effect="Allow",
+                resources=["*"],
+            )
+        ]
+    ).json,
     tags=tagger.create_tags(f"{base_name}-ses-policy"),
+    opts=ResourceOptions(parent=smtp_user),
 )
 
 # finally attach the policy to the user so it can send emails
-aws.iam.UserPolicyAttachment(
-    "smtp", user=smtp_user.name, policy_arn=policy.arn,
+UserPolicyAttachment(
+    resource_name="smtp",
+    user=smtp_user.name,
+    policy_arn=policy.arn,
+    opts=ResourceOptions(parent=smtp_user),
 )

--- a/infra/mwaa.py
+++ b/infra/mwaa.py
@@ -11,7 +11,7 @@ from pulumi_aws.mwaa import (
 )
 from pulumi_aws.ses import EmailIdentity
 
-from .base import base_name, environment_name, mwaa_config, stack, tagger
+from .base import base_name, environment_name, mwaa_config, stack, tagger, region
 from .iam.role_policies import executionRolePolicy
 from .iam.roles import executionRole
 from .iam.smtp_user import access_key
@@ -20,11 +20,11 @@ from .vpc import private_subnets, securityGroup
 
 smtp_user = access_key.id
 smtp_password = access_key.ses_smtp_password_v4
-smtp_config = mwaa_config['smtp']
+smtp_config = mwaa_config["smtp"]
 
 ses_email = EmailIdentity(
     resource_name="data_engineering_email",
-    email="dataengineering@digital.justice.gov.uk",
+    email=smtp_config["smtp_mail_from"],
 )
 
 environment = Environment(
@@ -34,11 +34,11 @@ environment = Environment(
     environment_class=mwaa_config["environment_class"],
     execution_role_arn=executionRole.arn,
     airflow_configuration_options={
-        "smtp.smtp_host": smtp_config['smtp_host'],
-        "smtp.smtp_port": smtp_config['smtp_port'],
+        "smtp.smtp_host": f"{smtp_config['smtp_host']}.{region}.amazonaws.com",
+        "smtp.smtp_port": smtp_config["smtp_port"],
         "smtp.smtp_user": smtp_user,
         "smtp.smtp_password": smtp_password,
-        "smtp.smtp_mail_from": smtp_config['smtp_mail_from'],
+        "smtp.smtp_mail_from": smtp_config["smtp_mail_from"],
         "smtp.smtp_starttls": True,
     },
     logging_configuration=EnvironmentLoggingConfigurationArgs(


### PR DESCRIPTION
Currently, the new Airflow environments are not configured to use a mailserver to send email notifications to DAG owners, as currently happens on Airflow 1.0. We will use amazon simple email service to email users.

Summary of changes:
- Add IAM smtp user and ses email identity
- Add smtp configs to mwaa configuration options  
- Update readme