### PR TITLE
Upgrade Kubernetes to 1.23 🚀

### DIFF
--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -39,7 +39,7 @@ config:
           - arn:aws:iam::189157455002:role/restricted-admin
           - arn:aws:iam::042130406152:role/github-actions-runner
       vpc_cni:
-        image_version: 1.11.2
+        image_version: 1.11.3
         image_account_id: 602401143452
     cluster_autoscaler:
       chart_version: 9.19.1

--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -44,7 +44,7 @@ config:
     cluster_autoscaler:
       chart_version: 9.20.1
     gatekeeper:
-      chart_version: 3.6.0
+      chart_version: 3.9.0
     kube2iam:
       chart_version: 2.6.0
   data-engineering-airflow:mwaa:

--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -42,7 +42,7 @@ config:
         image_version: 1.11.3
         image_account_id: 602401143452
     cluster_autoscaler:
-      chart_version: 9.19.1
+      chart_version: 9.20.1
     gatekeeper:
       chart_version: 3.6.0
     kube2iam:

--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -5,10 +5,10 @@ config:
   aws:region: eu-west-1
   data-engineering-airflow:eks:
     cluster:
-      kubernetes_version: "1.22"
+      kubernetes_version: "1.23"
       node_groups:
         - name: standard
-          ami_release_version: 1.22.9-20220610
+          ami_release_version: 1.23.9-20220824
           instance_types:
             - t3a.large
             - t3.large
@@ -19,7 +19,7 @@ config:
             min_size: 0
           disk_size: 150
         - name: high-memory
-          ami_release_version: 1.22.9-20220610
+          ami_release_version: 1.23.9-20220824
           instance_types:
             - r6i.4xlarge
           labels:

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -44,7 +44,7 @@ config:
         image_version: 1.11.3
         image_account_id: 602401143452
     cluster_autoscaler:
-      chart_version: 9.19.1
+      chart_version: 9.20.1
     gatekeeper:
       chart_version: 3.6.0
     kube2iam:

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -46,7 +46,7 @@ config:
     cluster_autoscaler:
       chart_version: 9.20.1
     gatekeeper:
-      chart_version: 3.6.0
+      chart_version: 3.9.0
     kube2iam:
       chart_version: 2.6.0
   data-engineering-airflow:mwaa:

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -5,10 +5,10 @@ config:
   aws:region: eu-west-1
   data-engineering-airflow:eks:
     cluster:
-      kubernetes_version: "1.22"
+      kubernetes_version: "1.23"
       node_groups:
         - name: standard
-          ami_release_version: 1.22.9-20220610
+          ami_release_version: 1.23.9-20220824
           capacity_type: ON_DEMAND
           instance_types:
             - t3a.large
@@ -20,7 +20,7 @@ config:
             min_size: 1
           disk_size: 150
         - name: high-memory
-          ami_release_version: 1.22.9-20220610
+          ami_release_version: 1.23.9-20220824
           capacity_type: ON_DEMAND
           instance_types:
             - r6i.4xlarge

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -41,7 +41,7 @@ config:
           - arn:aws:iam::189157455002:role/restricted-admin
           - arn:aws:iam::042130406152:role/github-actions-runner
       vpc_cni:
-        image_version: 1.11.2
+        image_version: 1.11.3
         image_account_id: 602401143452
     cluster_autoscaler:
       chart_version: 9.19.1

--- a/Pulumi.sandpit.yaml
+++ b/Pulumi.sandpit.yaml
@@ -39,7 +39,7 @@ config:
           - arn:aws:iam::189157455002:role/restricted-admin
           - arn:aws:iam::042130406152:role/github-actions-runner
       vpc_cni:
-        image_version: 1.11.2
+        image_version: 1.11.3
         image_account_id: 602401143452
     cluster_autoscaler:
       chart_version: 9.19.1

--- a/Pulumi.sandpit.yaml
+++ b/Pulumi.sandpit.yaml
@@ -5,9 +5,9 @@ config:
   aws:region: eu-west-1
   data-engineering-airflow:eks:
     cluster:
-      kubernetes_version: "1.22"
+      kubernetes_version: "1.23"
       node_groups:
-        - ami_release_version: 1.22.9-20220610
+        - ami_release_version: 1.23.9-20220824
           instance_types:
             - t3a.small
             - t3.small
@@ -18,7 +18,7 @@ config:
             max_size: 5
             min_size: 0
           disk_size: 20
-        - ami_release_version: 1.22.9-20220610
+        - ami_release_version: 1.23.9-20220824
           instance_types:
             - r6i.4xlarge
           labels:

--- a/Pulumi.sandpit.yaml
+++ b/Pulumi.sandpit.yaml
@@ -44,7 +44,7 @@ config:
     cluster_autoscaler:
       chart_version: 9.20.1
     gatekeeper:
-      chart_version: 3.6.0
+      chart_version: 3.9.0
     kube2iam:
       chart_version: 2.6.0
   data-engineering-airflow:mwaa:

--- a/Pulumi.sandpit.yaml
+++ b/Pulumi.sandpit.yaml
@@ -42,7 +42,7 @@ config:
         image_version: 1.11.3
         image_account_id: 602401143452
     cluster_autoscaler:
-      chart_version: 9.19.1
+      chart_version: 9.20.1
     gatekeeper:
       chart_version: 3.6.0
     kube2iam:

--- a/README.md
+++ b/README.md
@@ -123,26 +123,26 @@ affinity:
 To deploy or update an environment:
 
 1. Create an AWS Vault session with the `restricted-admin@data-engineering`
-    role:
+   role:
 
-    ```zsh
-    aws-vault exec -d 12h restricted-admin@data-engineering
-    ```
+   ```zsh
+   aws-vault exec -d 12h restricted-admin@data-engineering
+   ```
 
 2. Select the relevant stack, for example, `dev`:
 
-    ```zsh
-    pulumi stack select dev
-    ```
+   ```zsh
+   pulumi stack select dev
+   ```
 
 3. Update the stack:
 
-    ```zsh
-    pulumi up --refresh
-    ```
+   ```zsh
+   pulumi up --refresh
+   ```
 
-    If you get an error message during the update, try to run the update again
-    before debugging.
+   If you get an error message during the update, try to run the update again
+   before debugging.
 
 ### How to upgrade the Kubernetes version
 
@@ -174,6 +174,42 @@ For all available VPC CNI versions see the [GitHub releases](https://github.com/
 
 To upgrade the VPC CNI version, change the value of the
 `eks.cluster.vpc_cni_version` field in the relevant Pulumi stack config.
+
+### How to upgrade the cluster autoscaler version
+
+For all available chart versions, run:
+
+```zsh
+helm repo add autoscaler https://kubernetes.github.io/autoscaler
+helm search repo autoscaler/cluster-autoscaler --versions
+```
+
+To upgrade the cluster autoscaler version, change the value of the
+`eks.cluster_autoscaler.chart_version` field in the relevant Pulumi stack config.
+
+### How to upgrade the Gatekeeper version
+
+For all available chart versions, run:
+
+```zsh
+helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts
+helm search repo gatekeeper/gatekeeper --versions
+```
+
+To upgrade the Gatekeeper version, change the value of the
+`eks.gatekeeper.chart_version` field in the relevant Pulumi stack config.
+
+### How to upgrade the kube2iam version
+
+For all available chart versions, run:
+
+```zsh
+helm repo add kube2iam https://jtblin.github.io/kube2iam/
+helm search repo kube2iam/kube2iam --versions
+```
+
+To upgrade the kube2iam version, change the value of the `eks.kube2iam.chart_version`
+field in the relevant Pulumi stack config.
 
 ### How to run tests
 


### PR DESCRIPTION
This PR will:

- upgrade to Kubernetes v1.23
- upgrade all AMIs to the latest version
- upgrade the VPC CNI to v1.11.3
- upgrade the cluster autoscaler to v9.20.1
- upgrade Gatekeeper to v3.9.0