### PR TITLE
Set up kubectl in up workflow

### DIFF
--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -54,7 +54,7 @@ jobs:
           sudo ./aws/install --update
           aws --version
       - name: Set up kubectl
-        uses: azure/setup-kubectl@v2.0
+        uses: azure/setup-kubectl@v3
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/pulumi_up.yaml
+++ b/.github/workflows/pulumi_up.yaml
@@ -53,6 +53,8 @@ jobs:
           unzip awscliv2.zip
           sudo ./aws/install --update
           aws --version
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v3
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
This PR will:

- Ensure that the latest version of kubectl is installed during the `pulumi up` workflow
- upgrade to the latest version of the `setup-kubectl` Action