### PR TITLE
DATA-231 Add pentester group to cluster admins

### DIFF
--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -38,6 +38,7 @@ config:
           - arn:aws:iam::593291632749:role/restricted-admin
           - arn:aws:iam::189157455002:role/restricted-admin
           - arn:aws:iam::042130406152:role/github-actions-runner
+          - arn:aws:iam::593291632749:role/PenTester
       vpc_cni:
         image_version: 1.11.3
         image_account_id: 602401143452

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -40,6 +40,7 @@ config:
           - arn:aws:iam::593291632749:role/restricted-admin
           - arn:aws:iam::189157455002:role/restricted-admin
           - arn:aws:iam::042130406152:role/github-actions-runner
+          - arn:aws:iam::593291632749:role/PenTester
       vpc_cni:
         image_version: 1.11.3
         image_account_id: 602401143452

--- a/Pulumi.sandpit.yaml
+++ b/Pulumi.sandpit.yaml
@@ -38,6 +38,7 @@ config:
           - arn:aws:iam::593291632749:role/restricted-admin
           - arn:aws:iam::189157455002:role/restricted-admin
           - arn:aws:iam::042130406152:role/github-actions-runner
+          - arn:aws:iam::593291632749:role/PenTester
       vpc_cni:
         image_version: 1.11.3
         image_account_id: 602401143452


### PR DESCRIPTION
This PR is to add the pentester group to the `system:master` roles. This should be merged into main outside business hours, ideally with announcement in airflow to flag minor disruption.