### PR TITLE
DATA-327 Remove Pentester Group

### DIFF
--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -38,7 +38,6 @@ config:
           - arn:aws:iam::593291632749:role/restricted-admin
           - arn:aws:iam::189157455002:role/restricted-admin
           - arn:aws:iam::042130406152:role/github-actions-runner
-          - arn:aws:iam::593291632749:role/PenTester
       vpc_cni:
         image_version: 1.11.3
         image_account_id: 602401143452

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -40,7 +40,6 @@ config:
           - arn:aws:iam::593291632749:role/restricted-admin
           - arn:aws:iam::189157455002:role/restricted-admin
           - arn:aws:iam::042130406152:role/github-actions-runner
-          - arn:aws:iam::593291632749:role/PenTester
       vpc_cni:
         image_version: 1.11.3
         image_account_id: 602401143452

--- a/Pulumi.sandpit.yaml
+++ b/Pulumi.sandpit.yaml
@@ -38,7 +38,6 @@ config:
           - arn:aws:iam::593291632749:role/restricted-admin
           - arn:aws:iam::189157455002:role/restricted-admin
           - arn:aws:iam::042130406152:role/github-actions-runner
-          - arn:aws:iam::593291632749:role/PenTester
       vpc_cni:
         image_version: 1.11.3
         image_account_id: 602401143452


### PR DESCRIPTION
This PR removes the NCC role from the list of trusted authorities in the cluster now that their work is done.