### PR TITLE
HOTFIX-patch-kyverno-exclusions

### DIFF
--- a/.github/workflows/pulumi_up.yaml
+++ b/.github/workflows/pulumi_up.yaml
@@ -83,5 +83,3 @@ jobs:
         run: |
           pulumi stack select -c ${{ matrix.stack }}
           pulumi up --refresh --yes --skip-preview
-          aws eks --region eu-west-1 update-kubeconfig --name airflow-${{ matrix.stack }}
-          kubectl replace -f ./infra/eks/polcies/kyv.excluded_namespaces.yaml

--- a/.github/workflows/pulumi_up.yaml
+++ b/.github/workflows/pulumi_up.yaml
@@ -83,3 +83,5 @@ jobs:
         run: |
           pulumi stack select -c ${{ matrix.stack }}
           pulumi up --refresh --yes --skip-preview
+          aws eks --region eu-west-1 update-kubeconfig --name airflow-${{ matrix.stack }}
+          kubectl replace -f ./infra/eks/polcies/kyv.excluded_namespaces.yaml

--- a/README.md
+++ b/README.md
@@ -144,6 +144,21 @@ To deploy or update an environment:
    If you get an error message during the update, try to run the update again
    before debugging.
 
+4. On making changes to kyverno:
+
+   If you have updated/upgraded the kyverno deployment, you will need to
+   re-deploy our modified config file. This is not currently possible via
+   pulumi (see https://github.com/pulumi/pulumi-kubernetes/issues/264), so
+   must be done as a manual step using the following commands.
+
+   ```zsh
+   aws eks --region eu-west-1 update-kubeconfig --name airflow-<stack_name>}
+   kubectl replace -f ./infra/eks/polcies/kyv.excluded_namespaces.yaml
+   ```
+
+This will correctly update the kyverno settings for the current environment.
+The github action will do this automatically on each PR merge.
+
 ### How to upgrade the Kubernetes version
 
 For all available Kubernetes versions, see the

--- a/README.md
+++ b/README.md
@@ -144,18 +144,6 @@ To deploy or update an environment:
    If you get an error message during the update, try to run the update again
    before debugging.
 
-4. On making changes to kyverno:
-
-   If you have updated/upgraded the kyverno deployment, you will need to
-   re-deploy our modified config file. This is not currently possible via
-   pulumi (see https://github.com/pulumi/pulumi-kubernetes/issues/264), so
-   must be done as a manual step using the following commands.
-
-   ```zsh
-   aws eks --region eu-west-1 update-kubeconfig --name airflow-<stack_name>}
-   kubectl replace -f ./infra/eks/polcies/kyv.excluded_namespaces.yaml
-   ```
-
 This will correctly update the kyverno settings for the current environment.
 The github action will do this automatically on each PR merge.
 

--- a/infra/eks/kyverno.py
+++ b/infra/eks/kyverno.py
@@ -18,12 +18,16 @@ kyverno_namespace = k8s.core.v1.Namespace(
     ),
 )
 
-excluded_namespaces = ["kube-system", "kube2iam-system", "cluster-autoscaler-system"]
+excluded_namespaces = [
+    "kube-system",
+    "kube2iam-system",
+    "cluster-autoscaler-system",
+]
 # Deploys Keyverno based on the chart specified in the stack .yaml
 kyverno = k8s.helm.v3.Release(
     resource_name="kyverno",
     chart="kyverno",
-    create_namespace=False,
+    create_namespace=True,
     repository_opts=k8s.helm.v3.RepositoryOptsArgs(
         repo="https://kyverno.github.io/kyverno/"
     ),

--- a/infra/eks/kyverno.py
+++ b/infra/eks/kyverno.py
@@ -18,17 +18,19 @@ kyverno_namespace = k8s.core.v1.Namespace(
     ),
 )
 
+excluded_namespaces = ["kube-system", "kube2iam-system", "cluster-autoscaler-system"]
 # Deploys Keyverno based on the chart specified in the stack .yaml
 kyverno = k8s.helm.v3.Release(
     resource_name="kyverno",
     chart="kyverno",
-    create_namespace=True,
+    create_namespace=False,
     repository_opts=k8s.helm.v3.RepositoryOptsArgs(
         repo="https://kyverno.github.io/kyverno/"
     ),
     name="kyverno",
     namespace=kyverno_namespace.metadata.name,
     skip_await=False,
+    values={"resourceFiltersExcludeNamespaces": excluded_namespaces},
     version=eks_config["kyverno"]["chart_version"],
     opts=ResourceOptions(
         provider=cluster_provider,

--- a/infra/eks/kyverno.py
+++ b/infra/eks/kyverno.py
@@ -41,21 +41,13 @@ kyverno = k8s.helm.v3.Release(
 # Generic path to append specific policy locations to
 policy_path = str(Path(__file__).parent) + "/policies/"
 
-excluded_namespaces = k8s.yaml.ConfigFile(
-    "kyverno-excluded-namespaces",
-    policy_path + "kyv.excluded_namespaces.yaml",
-    opts=ResourceOptions(
-        provider=cluster_provider, delete_before_replace=True, parent=kyverno
-    ),
-)
-
 kyverno_privilege = k8s.yaml.ConfigFile(
     "kyverno-privilege-escalation",
     policy_path + "kyv.privilege_escalation.yaml",
     opts=ResourceOptions(
         provider=cluster_provider,
         delete_before_replace=True,
-        parent=excluded_namespaces,
+        parent=kyverno,
     ),
 )
 
@@ -65,7 +57,7 @@ kyverno_non_root = k8s.yaml.ConfigFile(
     opts=ResourceOptions(
         provider=cluster_provider,
         delete_before_replace=True,
-        parent=excluded_namespaces,
+        parent=kyverno,
     ),
 )
 
@@ -75,6 +67,6 @@ kyverno_non_root_user = k8s.yaml.ConfigFile(
     opts=ResourceOptions(
         provider=cluster_provider,
         delete_before_replace=True,
-        parent=excluded_namespaces,
+        parent=kyverno,
     ),
 )

--- a/infra/eks/kyverno.py
+++ b/infra/eks/kyverno.py
@@ -18,10 +18,23 @@ kyverno_namespace = k8s.core.v1.Namespace(
     ),
 )
 
-excluded_namespaces = [
-    "kube-system",
-    "kube2iam-system",
-    "cluster-autoscaler-system",
+statement = [
+    "[Event,*,*],"
+    "[*,kube-system,*],"
+    "[*,kube2iam-system,*],"
+    "[*,cluster-autoscaler-system,*],"
+    "[*,kube-public,*],"
+    "[*,kube-node-lease,*],"
+    "[Node,*,*],"
+    "[APIService,*,*],"
+    "[TokenReview,*,*],"
+    "[SubjectAccessReview,*,*],"
+    "[SelfSubjectAccessReview,*,*],"
+    "[*,kyverno,*],"
+    "[Binding,*,*],"
+    "[ReplicaSet,*,*],"
+    "[ReportChangeRequest,*,*],"
+    "[ClusterReportChangeRequest,*,*]"
 ]
 # Deploys Keyverno based on the chart specified in the stack .yaml
 kyverno = k8s.helm.v3.Release(
@@ -34,7 +47,7 @@ kyverno = k8s.helm.v3.Release(
     name="kyverno",
     namespace=kyverno_namespace.metadata.name,
     skip_await=False,
-    values={"resourceFiltersExcludeNamespaces": excluded_namespaces},
+    values={"config": {"resourceFilters": statement}},
     version=eks_config["kyverno"]["chart_version"],
     opts=ResourceOptions(
         provider=cluster_provider,

--- a/infra/eks/policies/kyv.excluded_namespaces.yaml
+++ b/infra/eks/policies/kyv.excluded_namespaces.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kyverno
-  namespace: kyverno
-data:
-  # resource types to be skipped by Kyverno
-  resourceFilters: '[Event,*,*][*,kube-system,*][*,kube2iam-system,*][*,cluster-autoscaler-system,*][*,kube-public,*][*,kube-node-lease,*][Node,*,*][APIService,*,*][TokenReview,*,*][SubjectAccessReview,*,*][SelfSubjectAccessReview,*,*][*,kyverno,*][Binding,*,*][ReplicaSet,*,*][ReportChangeRequest,*,*][ClusterReportChangeRequest,*,*]'

--- a/infra/eks/policies/kyv.excluded_namespaces.yaml
+++ b/infra/eks/policies/kyv.excluded_namespaces.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: excluded-namespaces
-  namespace: airflow
+  name: kyverno
+  namespace: kyverno
 data:
-  namespaces: "[\"cluster-autoscaler-system\", \"kube-system\", \"kube2iam-system\", \"kyverno\"]"
+  # resource types to be skipped by Kyverno
+  resourceFilters: '[Event,*,*][*,kube-system,*][*,kube2iam-system,*][*,cluster-autoscaler-system,*][*,kube-public,*][*,kube-node-lease,*][Node,*,*][APIService,*,*][TokenReview,*,*][SubjectAccessReview,*,*][SelfSubjectAccessReview,*,*][*,kyverno,*][Binding,*,*][ReplicaSet,*,*][ReportChangeRequest,*,*][ClusterReportChangeRequest,*,*]'

--- a/infra/eks/policies/kyv.privilege_escalation.yaml
+++ b/infra/eks/policies/kyv.privilege_escalation.yaml
@@ -11,41 +11,31 @@ metadata:
     kyverno.io/kubernetes-version: "1.22-1.23"
     policies.kyverno.io/description: >-
       Privilege escalation, such as via set-user-ID or set-group-ID file mode, should not be allowed.
-      This policy ensures the `allowPrivilegeEscalation` field is set to `false`.
+      This policy ensures the `allowPrivilegeEscalation` field is set to `false`.      
 spec:
   validationFailureAction: enforce
   background: true
   rules:
     - name: privilege-escalation
-      context:
-      - name: excluded-namespaces
-        configMap:
-          name: excluded-namespaces
-          namespace: airflow
       match:
         any:
         - resources:
             kinds:
               - Pod
-      preconditions:
-      all:
-      - key: "{{request.object.metadata.namespace}}"
-        operator: AnyNotIn
-        value: "{{excluded-namespaces.data.namespaces}}"
       validate:
         message: >-
           Privilege escalation is disallowed. The fields
           spec.containers[*].securityContext.allowPrivilegeEscalation,
           spec.initContainers[*].securityContext.allowPrivilegeEscalation,
           and spec.ephemeralContainers[*].securityContext.allowPrivilegeEscalation
-          must be set to `false`.
+          must be set to `false`.          
         pattern:
           spec:
             =(ephemeralContainers):
-            - =(securityContext):
+            - securityContext:
                 allowPrivilegeEscalation: "false"
             =(initContainers):
-            - =(securityContext):
+            - securityContext:
                 allowPrivilegeEscalation: "false"
             =(containers):
             - =(securityContext):

--- a/infra/eks/policies/kyv.privilege_escalation.yaml
+++ b/infra/eks/policies/kyv.privilege_escalation.yaml
@@ -11,7 +11,7 @@ metadata:
     kyverno.io/kubernetes-version: "1.22-1.23"
     policies.kyverno.io/description: >-
       Privilege escalation, such as via set-user-ID or set-group-ID file mode, should not be allowed.
-      This policy ensures the `allowPrivilegeEscalation` field is set to `false`.      
+      This policy ensures the `allowPrivilegeEscalation` field is set to `false`.
 spec:
   validationFailureAction: enforce
   background: true
@@ -28,14 +28,14 @@ spec:
           spec.containers[*].securityContext.allowPrivilegeEscalation,
           spec.initContainers[*].securityContext.allowPrivilegeEscalation,
           and spec.ephemeralContainers[*].securityContext.allowPrivilegeEscalation
-          must be set to `false`.          
+          must be set to `false`.
         pattern:
           spec:
             =(ephemeralContainers):
-            - securityContext:
+            - =(securityContext):
                 allowPrivilegeEscalation: "false"
             =(initContainers):
-            - securityContext:
+            - =(securityContext):
                 allowPrivilegeEscalation: "false"
             =(containers):
             - =(securityContext):

--- a/infra/eks/policies/kyv.run_as_non_root.yaml
+++ b/infra/eks/policies/kyv.run_as_non_root.yaml
@@ -18,21 +18,11 @@ spec:
   background: true
   rules:
     - name: run-as-non-root
-      context:
-      - name: excluded-namespaces
-        configMap:
-          name: excluded-namespaces
-          namespace: airflow
       match:
         any:
         - resources:
             kinds:
               - Pod
-      preconditions:
-      all:
-      - key: "{{request.object.metadata.namespace}}"
-        operator: AnyNotIn
-        value: "{{excluded-namespaces.data.namespaces}}"
       validate:
         message: >-
           Running as root is not allowed. Either the field spec.securityContext.runAsNonRoot

--- a/infra/eks/policies/kyv.run_as_non_root_user.yaml
+++ b/infra/eks/policies/kyv.run_as_non_root_user.yaml
@@ -17,21 +17,11 @@ spec:
   background: true
   rules:
     - name: run-as-non-root-user
-      context:
-      - name: excluded-namespaces
-        configMap:
-          name: excluded-namespaces
-          namespace: airflow
       match:
         any:
         - resources:
             kinds:
               - Pod
-      preconditions:
-      all:
-      - key: "{{request.object.metadata.namespace}}"
-        operator: AnyNotIn
-        value: "{{excluded-namespaces.data.namespaces}}"
       validate:
         message: >-
           Running as root is not allowed. The fields spec.securityContext.runAsUser,


### PR DESCRIPTION
Due to the issues laid out in this issues page:
https://github.com/pulumi/pulumi-kubernetes/issues/264
It's not possible to make a modification to a configmap created by a helm-chart, as opposed to those we explicitly create via pulumi.

Kyverno does not seem to like specifying excluded namespaces per rule. Until such time as a solution to this is formulated, the easiest and only known way of excluding namespaces is via a 'resource filter' as detailed here in the kyverno docs:

https://kyverno.io/docs/installation/#resource-filters

The main issue is, this requires us to modify a configmap that is automatically generated as part of the kyverno install. This is currently not possible via pulumi. This PR instead modifies the github action to manually patch the file using kubectl. This will only need to run if we upgrade the helm chart, but running it when the content is the same in the cluster and the local file has no ill-effects.