### PR TITLE
HOTFIX-revert-kyverno

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,5 +1,5 @@
 from infra import base, mwaa, s3, vpc
-from infra.eks import airflow, cluster, cluster_autoscaler, kube2iam, kyverno
+from infra.eks import airflow, cluster, cluster_autoscaler, kube2iam
 from infra.iam import policies, role_policies, roles
 
 __all__ = [
@@ -7,7 +7,6 @@ __all__ = [
     "base",
     "cluster",
     "cluster_autoscaler",
-    "kyverno",
     "kube2iam",
     "mwaa",
     "policies",

--- a/infra/eks/kyverno.py
+++ b/infra/eks/kyverno.py
@@ -1,12 +1,10 @@
-from pathlib import Path
+""" from pathlib import Path
 
 import pulumi_kubernetes as k8s
 from pulumi import Alias, ResourceOptions
 
 from ..base import eks_config
 from .cluster import cluster, cluster_provider
-
-# See https://github.com/open-policy-agent/gatekeeper-library/
 
 kyverno_namespace = k8s.core.v1.Namespace(
     resource_name="kyverno-system",
@@ -78,3 +76,4 @@ kyverno_non_root_user = k8s.yaml.ConfigFile(
         parent=excluded_namespaces,
     ),
 )
+ """


### PR DESCRIPTION
**WARNING - DO NOT MERGE UNLESS ABSOLUTELY NECESSARY!!!!**

This PR removes the current kyverno implementation. This is only to be deployed in the event of a critical airflow blocker.