### PR TITLE
DATA-230 Transit Gateway Migration + assorted hotfixes

### DIFF
--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -63,13 +63,13 @@ config:
     transit_gateways:
       - name: cloud-platform
         id: tgw-009e14703041026a5
+      - name: moj
+        id: tgw-0e7b982ea47c28fba
         routes:
           - name: noms-live
             cidr_block: 10.40.0.0/18
           - name: modernisation-platform
             cidr_block: 10.26.0.0/15
-      - name: moj
-        id: tgw-0e7b982ea47c28fba
     private_subnets:
       cidr_blocks:
         - 10.200.20.0/24

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -65,6 +65,8 @@ config:
     transit_gateways:
       - name: cloud-platform
         id: tgw-009e14703041026a5
+      - name: moj
+        id: tgw-0e7b982ea47c28fba
         routes:
           - name: noms-live
             cidr_block: 10.40.0.0/18
@@ -72,8 +74,6 @@ config:
             cidr_block: 10.205.0.0/20
           - name: modernisation-platform
             cidr_block: 10.26.0.0/15
-      - name: moj
-        id: tgw-0e7b982ea47c28fba
     private_subnets:
       cidr_blocks:
         - 10.201.20.0/24

--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ To deploy or update an environment:
    If you get an error message during the update, try to run the update again
    before debugging.
 
+This will correctly update the kyverno settings for the current environment.
+The github action will do this automatically on each PR merge.
+
 ### How to upgrade the Kubernetes version
 
 For all available Kubernetes versions, see the

--- a/infra/eks/policies/kyv.excluded_namespaces.yaml
+++ b/infra/eks/policies/kyv.excluded_namespaces.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: excluded-namespaces
-  namespace: airflow
-data:
-  namespaces: "[\"cluster-autoscaler-system\", \"kube-system\", \"kube2iam-system\", \"kyverno\"]"

--- a/infra/eks/policies/kyv.privilege_escalation.yaml
+++ b/infra/eks/policies/kyv.privilege_escalation.yaml
@@ -17,21 +17,11 @@ spec:
   background: true
   rules:
     - name: privilege-escalation
-      context:
-      - name: excluded-namespaces
-        configMap:
-          name: excluded-namespaces
-          namespace: airflow
       match:
         any:
         - resources:
             kinds:
               - Pod
-      preconditions:
-      all:
-      - key: "{{request.object.metadata.namespace}}"
-        operator: AnyNotIn
-        value: "{{excluded-namespaces.data.namespaces}}"
       validate:
         message: >-
           Privilege escalation is disallowed. The fields

--- a/infra/eks/policies/kyv.run_as_non_root.yaml
+++ b/infra/eks/policies/kyv.run_as_non_root.yaml
@@ -18,21 +18,11 @@ spec:
   background: true
   rules:
     - name: run-as-non-root
-      context:
-      - name: excluded-namespaces
-        configMap:
-          name: excluded-namespaces
-          namespace: airflow
       match:
         any:
         - resources:
             kinds:
               - Pod
-      preconditions:
-      all:
-      - key: "{{request.object.metadata.namespace}}"
-        operator: AnyNotIn
-        value: "{{excluded-namespaces.data.namespaces}}"
       validate:
         message: >-
           Running as root is not allowed. Either the field spec.securityContext.runAsNonRoot

--- a/infra/eks/policies/kyv.run_as_non_root_user.yaml
+++ b/infra/eks/policies/kyv.run_as_non_root_user.yaml
@@ -17,21 +17,11 @@ spec:
   background: true
   rules:
     - name: run-as-non-root-user
-      context:
-      - name: excluded-namespaces
-        configMap:
-          name: excluded-namespaces
-          namespace: airflow
       match:
         any:
         - resources:
             kinds:
               - Pod
-      preconditions:
-      all:
-      - key: "{{request.object.metadata.namespace}}"
-        operator: AnyNotIn
-        value: "{{excluded-namespaces.data.namespaces}}"
       validate:
         message: >-
           Running as root is not allowed. The fields spec.securityContext.runAsUser,


### PR DESCRIPTION
This PR would migrate our routes to the new TGW - based on the experience of managed pipelines, may need to be a two-step deploy. Due to the changes being made, this PR will effectively be a rubber stamp PR, as all changes contained within will already have been manually deployed from my PC to allow for phased deployment.