### PR TITLE
DATA-336 add a default python pod spec with no privilages.

### DIFF
--- a/infra/default_pod_spec.yaml
+++ b/infra/default_pod_spec.yaml
@@ -6,10 +6,17 @@ metadata:
   annotations: 
     iam.amazonaws.com/role: no_role
 spec:
+  securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
   containers:
     - name: default_python_pod
       image: 189157455002.dkr.ecr.eu-west-1.amazonaws.com/python:3.8-slim
-      imagePullPolicy: IfNotPresent
-  securityContext:
-    runAsNonRoot: true
-    runAsUser: 1000
+      imagePullPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 451000
+        allowPrivilegeEscalation: false
+        capabilities:
+            drop:
+            - ALL

--- a/infra/default_pod_spec.yaml
+++ b/infra/default_pod_spec.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: default_container
+  namespace: airflow
+  annotations: 
+    iam.amazonaws.com/role: no_role
+spec:
+  containers:
+    - name: default_python_pod
+      image: 189157455002.dkr.ecr.eu-west-1.amazonaws.com/python:3.8-slim
+      imagePullPolicy: IfNotPresent
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000

--- a/infra/s3.py
+++ b/infra/s3.py
@@ -52,3 +52,12 @@ BucketObject(
     key="dags/.kube/config",
     server_side_encryption="AES256",
 )
+
+BucketObject(
+    resource_name=f"{base_name}-default-pod-spec",
+    opts=ResourceOptions(parent=bucket, depends_on=[cluster]),
+    bucket=bucket.id,
+    source="./infra/default_pod_spec.yaml",
+    key="dags/.kube/default_pod_spec.yaml",
+    server_side_encryption="AES256",
+)


### PR DESCRIPTION
This PR adds a yaml spec with no permissions to the S3 buckets for each env, such that we can then pick it up as part of a [matching PR in the mojap-airflow-tools package](https://github.com/moj-analytical-services/mojap-airflow-tools/pull/20). The yaml file itself represents a python shell with no iam permissions (and therefore basically not able to do much), but as users will be specifying their own images the actual base image is of low relevance. 

Importantly, this default spec forces users to adhere to basic security principles, meaning the only way to avoid being secure would be to intentionally override the settings here, which should be obvious in the course of code review in the main airflow repo.

