### PR TITLE
DATA-408 Deploy new airflow release

### DIFF
--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -57,6 +57,8 @@ jobs:
         uses: azure/setup-kubectl@v3
       - name: Set up node
         uses: actions/setup-node@v3
+        with:
+          node-version: 18.14.0
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Remove existing Pulumi installations
         run: |
           rm -rf "$HOME/.pulumi"

--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -76,6 +76,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install wheel
           if [ -f requirements.txt ]; then pip install --upgrade -r requirements.txt; fi
       - name: Preview changes
         env:

--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -55,6 +55,8 @@ jobs:
           aws --version
       - name: Set up kubectl
         uses: azure/setup-kubectl@v3
+      - name: Set up node
+        uses: actions/setup-node@v3
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/pulumi_up.yaml
+++ b/.github/workflows/pulumi_up.yaml
@@ -55,6 +55,10 @@ jobs:
           aws --version
       - name: Set up kubectl
         uses: azure/setup-kubectl@v3
+      - name: Set up node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.14.0
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -5,10 +5,10 @@ config:
   aws:region: eu-west-1
   data-engineering-airflow:eks:
     cluster:
-      kubernetes_version: "1.23"
+      kubernetes_version: "1.24"
       node_groups:
         - name: standard
-          ami_release_version: 1.23.9-20220824
+          ami_release_version: 1.24.9-20230127
           instance_types:
             - t3a.large
             - t3.large
@@ -19,7 +19,7 @@ config:
             min_size: 0
           disk_size: 150
         - name: high-memory
-          ami_release_version: 1.23.9-20220824
+          ami_release_version: 1.24.9-20230127
           instance_types:
             - r6i.4xlarge
           labels:
@@ -48,15 +48,15 @@ config:
     kube2iam:
       chart_version: 2.6.0
   data-engineering-airflow:mwaa:
-    airflow_version: 2.2.2
+    airflow_version: 2.4.3
     environment_class: mw1.small
     max_workers: 2
     min_workers: 1
     requirements: |
-      --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.2.2/constraints-3.7.txt"
+      --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.4.3/constraints-3.10.txt"
       apache-airflow[cncf.kubernetes]
       kubernetes
-      mojap-airflow-tools==2.2.1
+      mojap-airflow-tools==2.4.3
     smtp_mail_from: dataengineering@digital.justice.gov.uk
   data-engineering-airflow:vpc:
     cidr_block: 10.200.0.0/16

--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -5,10 +5,10 @@ config:
   aws:region: eu-west-1
   data-engineering-airflow:eks:
     cluster:
-      kubernetes_version: "1.23"
+      kubernetes_version: "1.24"
       node_groups:
         - name: standard
-          ami_release_version: 1.23.9-20220824
+          ami_release_version: 1.24.9-20230127
           capacity_type: ON_DEMAND
           instance_types:
             - t3a.large
@@ -20,7 +20,7 @@ config:
             min_size: 1
           disk_size: 150
         - name: high-memory
-          ami_release_version: 1.23.9-20220824
+          ami_release_version: 1.24.9-20230127
           capacity_type: ON_DEMAND
           instance_types:
             - r6i.4xlarge
@@ -50,15 +50,15 @@ config:
     kube2iam:
       chart_version: 2.6.0
   data-engineering-airflow:mwaa:
-    airflow_version: 2.2.2
+    airflow_version: 2.4.3
     environment_class: mw1.medium
     max_workers: 10
     min_workers: 1
     requirements: |
-      --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.2.2/constraints-3.7.txt"
+      --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.4.3/constraints-3.10.txt"
       apache-airflow[cncf.kubernetes]
       kubernetes
-      mojap-airflow-tools==2.2.1
+      mojap-airflow-tools==2.4.3
     smtp_mail_from: dataengineering@digital.justice.gov.uk
   data-engineering-airflow:vpc:
     cidr_block: 10.201.0.0/16

--- a/Pulumi.sandpit.yaml
+++ b/Pulumi.sandpit.yaml
@@ -5,9 +5,9 @@ config:
   aws:region: eu-west-1
   data-engineering-airflow:eks:
     cluster:
-      kubernetes_version: "1.23"
+      kubernetes_version: "1.24"
       node_groups:
-        - ami_release_version: 1.23.9-20220824
+        - ami_release_version: 1.24.9-20230127
           instance_types:
             - t3a.small
             - t3.small
@@ -18,7 +18,7 @@ config:
             max_size: 5
             min_size: 0
           disk_size: 20
-        - ami_release_version: 1.23.9-20220824
+        - ami_release_version: 1.24.9-20230127
           instance_types:
             - r6i.4xlarge
           labels:
@@ -48,15 +48,15 @@ config:
     kube2iam:
       chart_version: 2.6.0
   data-engineering-airflow:mwaa:
-    airflow_version: 2.2.2
+    airflow_version: 2.4.3
     environment_class: mw1.small
     max_workers: 2
     min_workers: 1
     requirements: |
-      --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.2.2/constraints-3.7.txt"
+      --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.4.3/constraints-3.10.txt"
       apache-airflow[cncf.kubernetes]
       kubernetes
-      mojap-airflow-tools==2.2.1
+      mojap-airflow-tools==2.4.3
     smtp_mail_from: dataengineering@digital.justice.gov.uk
   data-engineering-airflow:vpc:
     cidr_block: 10.202.0.0/16

--- a/infra/mwaa.py
+++ b/infra/mwaa.py
@@ -36,6 +36,7 @@ environment = Environment(
         "smtp.smtp_password": accessKey.ses_smtp_password_v4,
         "smtp.smtp_mail_from": mwaa_config["smtp_mail_from"],
         "smtp.smtp_starttls": True,
+        "webserver.warn_deployment_exposure": False,
     },
     logging_configuration=EnvironmentLoggingConfigurationArgs(
         dag_processing_logs=EnvironmentLoggingConfigurationDagProcessingLogsArgs(

--- a/infra/s3.py
+++ b/infra/s3.py
@@ -32,7 +32,7 @@ bucket_policy = BucketPolicy(
     resource_name=f"mojap-{base_name}-bucket-policy",
     bucket=f"mojap-{base_name}",
     policy=policy,
-    opts=ResourceOptions(parent=bucket),
+    opts=ResourceOptions(parent=bucket, depends_on=bucket),
 )
 
 requirementsBucketObject = BucketObject(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ wheel
 data-engineering-pulumi-components>=0.4.0.dev1,<1.0.0
 pulumi>=3.0.0,<4.0.0
 pulumi-aws>=5.0.0,<6.0.0
-pulumi-eks>=0.30.0,<1.0.0
+pulumi-eks==0.41.2
 pulumi-kubernetes>=3.7.0,<=4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+wheel
 data-engineering-pulumi-components>=0.4.0.dev1,<1.0.0
 pulumi>=3.0.0,<4.0.0
 pulumi-aws>=5.0.0,<6.0.0


### PR DESCRIPTION
This PR brings the codebase in line with the deployed environment for Airflow - this PR saw the Airflow 2.4.3 upgrade, and the move to Kubernetes v1.24. In addition, this covers some minor fixes to our github actions required for them to function due to the deprecation of older versions of Node/npm.