### PR TITLE
Migrate Sandpit to using tools EKS cluster

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -3,7 +3,7 @@ name: MegaLinter
 on:
   pull_request:
     branches: [main]
-
+permissions: read-all
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -3,7 +3,8 @@ name: MegaLinter
 on:
   pull_request:
     branches: [main]
-permissions: read-all
+permissions:
+  pull-requests: write
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -71,9 +71,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.10"
-      - name: Remove existing Pulumi installations
+      - name: Remove runner Pulumi installations
         run: |
-          rm -rf "$HOME/.pulumi"
+          rm -rf "$HOME/runner/.pulumi"
       - name: Install Pulumi CLI
         uses: pulumi/setup-pulumi@v2
         with:

--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+permissions: read-all
 env:
   AWS_ROLE_TO_ASSUME: arn:aws:iam::189157455002:role/github-actions-infrastructure
 jobs:

--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -24,7 +24,7 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           role-skip-session-tagging: true
           role-duration-seconds: 3600
-      - name: Remove existing Pulumi installations
+      - name: Remove runner Pulumi installations
         run: |
           rm -rf "$HOME/runner/.pulumi"
       - name: Install Pulumi CLI

--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -88,4 +88,4 @@ jobs:
           PULUMI_CONFIG_PASSPHRASE: ""
         run: |
           pulumi stack select -c ${{ matrix.stack }}
-          pulumi preview --refresh
+          pulumi preview -d --refresh

--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -26,7 +26,7 @@ jobs:
           role-duration-seconds: 3600
       - name: Remove existing Pulumi installations
         run: |
-          rm -rf "$HOME/.pulumi"
+          rm -rf "$HOME/runner/.pulumi"
       - name: Install Pulumi CLI
         uses: moj-analytical-services/actions-setup-pulumi@main
       - name: Get Stacks

--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/setup-pulumi@v2
         with:
-          pulumi-version: ^3.0.0
+          pulumi-version: 3.55.0
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -9,7 +9,7 @@ env:
 jobs:
   get-stacks:
     name: Get Stacks
-    runs-on: [self-hosted, management-infrastructure]
+    runs-on: ubuntu-latest
     outputs:
       STACKS: ${{ steps.get-stacks.outputs.STACKS }}
     steps:

--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/setup-pulumi@v2
         with:
-          pulumi-version: 3.55.0
+          pulumi-version: 3.53.1
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pulumi_preview.yaml
+++ b/.github/workflows/pulumi_preview.yaml
@@ -88,4 +88,4 @@ jobs:
           PULUMI_CONFIG_PASSPHRASE: ""
         run: |
           pulumi stack select -c ${{ matrix.stack }}
-          pulumi preview -d --refresh
+          pulumi preview --refresh

--- a/.github/workflows/pulumi_up.yaml
+++ b/.github/workflows/pulumi_up.yaml
@@ -73,7 +73,7 @@ jobs:
           python-version: "3.9"
       - name: Remove existing Pulumi installations
         run: |
-          rm -rf "$HOME/.pulumi"
+          rm -rf "$HOME/runner/.pulumi"
       - name: Install Pulumi CLI
         uses: pulumi/setup-pulumi@v2
         with:

--- a/.github/workflows/pulumi_up.yaml
+++ b/.github/workflows/pulumi_up.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+permissions: read-all
 env:
   AWS_ROLE_TO_ASSUME: arn:aws:iam::189157455002:role/github-actions-infrastructure
 jobs:

--- a/.github/workflows/pulumi_up.yaml
+++ b/.github/workflows/pulumi_up.yaml
@@ -24,9 +24,9 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           role-skip-session-tagging: true
           role-duration-seconds: 3600
-      - name: Remove existing Pulumi installations
+      - name: Remove runner Pulumi installations
         run: |
-          rm -rf "$HOME/.pulumi"
+          rm -rf "$HOME/runner/.pulumi"
       - name: Install Pulumi CLI
         uses: pulumi/setup-pulumi@v2
       - name: Get Stacks

--- a/.github/workflows/pulumi_up.yaml
+++ b/.github/workflows/pulumi_up.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/setup-pulumi@v2
         with:
-          pulumi-version: ^3.0.0
+          pulumi-version: 3.53.1
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,7 @@
 name: Test
 on:
   - pull_request
+permissions: read-all
 jobs:
   test:
     name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ celerybeat.pid
 .venv
 env/
 venv/
+testvenv/
 ENV/
 env.bak/
 venv.bak/

--- a/infra/iam/role_policies.py
+++ b/infra/iam/role_policies.py
@@ -88,13 +88,19 @@ def get_execution_role_policy(args):
     ).json
 
 
+# Catch to keep sandpit separate for now
+if environment_name == "Sandpit":
+    cluster_arn = "arn:aws:eks:eu-west-1:312423030077:cluster/production-dBSvju9Y"
+else:
+    cluster_arn = cluster.core.cluster.arn
+
 executionRolePolicy = RolePolicy(
     resource_name=f"{base_name}-execution-role-policy",
     name=f"{base_name}-execution-role-policy",
     policy=Output.all(
         account_id=account_id,
         bucket_arn=bucket.arn,
-        cluster_arn=cluster.core.cluster.arn,
+        cluster_arn=cluster_arn
         environment_name=environment_name,
         region=region,
     ).apply(get_execution_role_policy),

--- a/infra/iam/role_policies.py
+++ b/infra/iam/role_policies.py
@@ -88,11 +88,10 @@ def get_execution_role_policy(args):
     ).json
 
 
-# Catch to keep sandpit separate for now
-""" if environment_name == "Sandpit":
+if environment_name == "Sandpit":
     cluster_arn = "arn:aws:eks:eu-west-1:312423030077:cluster/production-dBSvju9Y"
 else:
-    cluster_arn = cluster.core.cluster.arn """
+    cluster_arn = cluster.core.cluster.arn
 
 executionRolePolicy = RolePolicy(
     resource_name=f"{base_name}-execution-role-policy",

--- a/infra/iam/role_policies.py
+++ b/infra/iam/role_policies.py
@@ -100,7 +100,7 @@ executionRolePolicy = RolePolicy(
     policy=Output.all(
         account_id=account_id,
         bucket_arn=bucket.arn,
-        cluster_arn=cluster_arn
+        cluster_arn=cluster_arn,
         environment_name=environment_name,
         region=region,
     ).apply(get_execution_role_policy),

--- a/infra/iam/role_policies.py
+++ b/infra/iam/role_policies.py
@@ -89,10 +89,10 @@ def get_execution_role_policy(args):
 
 
 # Catch to keep sandpit separate for now
-if environment_name == "Sandpit":
+""" if environment_name == "Sandpit":
     cluster_arn = "arn:aws:eks:eu-west-1:312423030077:cluster/production-dBSvju9Y"
 else:
-    cluster_arn = cluster.core.cluster.arn
+    cluster_arn = cluster.core.cluster.arn """
 
 executionRolePolicy = RolePolicy(
     resource_name=f"{base_name}-execution-role-policy",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 wheel
 data-engineering-pulumi-components>=0.4.0.dev1,<1.0.0
-pulumi==3.55.0
-pulumi-aws==5.30.0
+pulumi==3.53.1
+pulumi-aws==5.28.0
 pulumi-eks==0.41.2
-pulumi-kubernetes>=3.7.0,<=4.0.0
+pulumi-kubernetes==3.21.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 wheel
 data-engineering-pulumi-components>=0.4.0.dev1,<1.0.0
-pulumi>=3.0.0,<4.0.0
+pulumi==3.55.0
 pulumi-aws==5.30.0
 pulumi-eks==0.41.2
 pulumi-kubernetes>=3.7.0,<=4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 wheel
 data-engineering-pulumi-components>=0.4.0.dev1,<1.0.0
 pulumi>=3.0.0,<4.0.0
-pulumi-aws>=5.0.0,<6.0.0
+pulumi-aws==5.30.0
 pulumi-eks==0.41.2
 pulumi-kubernetes>=3.7.0,<=4.0.0


### PR DESCRIPTION
This PR contains a new condition that allows the sandpit to take a specified EKS cluster as its execution target. Out of scope for this PR is decomissioning any infra (EKS, network etc.) that Sandpit will no longer need from this repo.